### PR TITLE
French translation 🥖

### DIFF
--- a/po/fr.pot
+++ b/po/fr.pot
@@ -1,69 +1,74 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# French translation for Alpaca
 #
-#, fuzzy
+# Translate guideline :
+#
+# English	French
+# to chat	discuter
+# a chat	une discussion
+#
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: 0.8.7\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-05-27 14:57-0600\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2024-05-28 17:15+0200\n"
+"Last-Translator: Louis Chauvet <louischauvet0@gmail.com>\n"
+"Language-Team: \n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.4\n"
 
 #: data/com.jeffser.Alpaca.desktop.in:3
 #: data/com.jeffser.Alpaca.metainfo.xml.in:7
 msgid "Alpaca"
-msgstr ""
+msgstr "Alpaga"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:8
 msgid "Chat with local AI models powered by Ollama"
-msgstr ""
+msgstr "Discutez avec des modèles d'IA fonctionnant localement grâce à Ollama"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:10
 msgid "An Ollama client"
-msgstr ""
+msgstr "Un client Ollama"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:11
 #: data/com.jeffser.Alpaca.metainfo.xml.in:311
 msgid "Features"
-msgstr ""
+msgstr "Fonctionnalités"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:13
 msgid "Built in Ollama instance"
-msgstr ""
+msgstr "Intégrée dans l'instance Ollama"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:14
 #: data/com.jeffser.Alpaca.metainfo.xml.in:313
 msgid "Talk to multiple models in the same conversation"
-msgstr ""
+msgstr "Discutez avec plusieurs modèles dans la même conversation"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:15
 #: data/com.jeffser.Alpaca.metainfo.xml.in:314
 msgid "Pull and delete models from the app"
-msgstr ""
+msgstr "Téléchargez et supprimez des modèles depuis l'application"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:16
 msgid "Have multiple conversations"
-msgstr ""
+msgstr "Ayez plusieurs conversations"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:17
 msgid "Image recognition (Only available with compatible models)"
 msgstr ""
+"Reconnaissance d'image (Uniquement disponible avec les modèles compatibles)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:18
 msgid "Import and export chats"
-msgstr ""
+msgstr "Importez et exportez des discussions"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:20 src/window.ui:440
 msgid "Disclaimer"
-msgstr ""
+msgstr "Avertissement"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:21
 msgid ""
@@ -71,178 +76,193 @@ msgid ""
 "any damages to your device or software caused by running code given by any "
 "models."
 msgstr ""
+"Ce projet n'est aucunement affilié avec Ollama, et je ne suis aucunement "
+"responsable des dommages causés à votre appareil ou vos logiciels en "
+"exécutant du code donné par n'importe quel modèle."
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:24
 msgid "Jeffry Samuel Eduarte Rojas"
-msgstr ""
+msgstr "Jeffry Samuel Eduarte Rojas"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:50
 msgid "A conversation showing code highlight"
-msgstr ""
+msgstr "Une conversation montrant code avec de la coloration syntaxique"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:54
 msgid "A conversation involving multiple models"
-msgstr ""
+msgstr "Une conversation utilisant plusieurs modèles"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:58
 msgid "Managing models"
-msgstr ""
+msgstr "Gestion des modèles"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:69
 msgid "Quick fixes"
-msgstr ""
+msgstr "Petites corrections"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:71
 msgid "Fixed: Scroll when message is received"
-msgstr ""
+msgstr "Correction: Défilement lors de la réception d'un message"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:72
 msgid "Fixed: Content doesn't change when creating a new chat"
 msgstr ""
+"Correction: Le contenu ne change pas lors de la création d'un nouveau chat"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:73
 msgid "Added 'Featured Models' page on welcome dialog"
 msgstr ""
+"Ajout de la page 'Modèles Suggérés' sur la fenêtre de dialogue d'accueil"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:80
 msgid "Nice Update"
-msgstr ""
+msgstr "Bonne mise à jour"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:82
 msgid "UI tweaks (Thanks Nokse22)"
-msgstr ""
+msgstr "Ajustement de l'interface utilisateur (Merci à Nokse22)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:83
 msgid "General optimizations"
-msgstr ""
+msgstr "Optimisations générales"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:84
 msgid "Metadata fixes"
-msgstr ""
+msgstr "Correction des métadonnées"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:91
 msgid "Quick fix"
-msgstr ""
+msgstr "Petite correction"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:93
 msgid "Updated Spanish translation"
-msgstr ""
+msgstr "Mise à jour de la traduction Espagnol"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:94
 msgid "Added compatibility for PNG"
-msgstr ""
+msgstr "Ajout de la compatibilité pour les images PNG"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:101
 msgid "New Update"
-msgstr ""
+msgstr "Nouvelle mise à jour"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:103
 msgid "Updated model list"
-msgstr ""
+msgstr "Liste des modèles mise à jour"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:104
 msgid "Added image recognition to more models"
-msgstr ""
+msgstr "Ajout de la reconnaissance d'image à plus de modèles"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:105
 msgid "Added Brazilian Portuguese translation (Thanks Daimaar Stein)"
-msgstr ""
+msgstr "Ajout de la traduction en Portugais Brésilien (Merci à Daimaar Stein)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:106
 msgid "Refined the general UI (Thanks Nokse22)"
-msgstr ""
+msgstr "Peaufinage de l'interface utilisateur (Merci à Nokse22)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:107
 msgid "Added 'delete message' feature"
-msgstr ""
+msgstr "Ajout de l'option 'supprimer le message'"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:108
 msgid ""
 "Added metadata so that software distributors know that the app is compatible "
 "with mobile"
 msgstr ""
+"Ajout de métadonnées pour que les distributeurs de logiciels sachent que "
+"l'application est compatible avec les téléphones"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:109
 msgid ""
 "Changed 'send' shortcut to just the return/enter key (to add a new line use "
 "shift+return)"
 msgstr ""
+"Changement du raccourci 'envoyer' en une simple touche retour/entrée (pour "
+"ajouter une nouvelle ligne, utiliser shift+retour)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:116
 msgid "Bug Fixes"
-msgstr ""
+msgstr "Résolution de bogues"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:118
 msgid "Fixed: Minor spelling mistake"
-msgstr ""
+msgstr "Corrigé: Petite faute d'orthographe"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:119
 msgid "Added 'mobile' as a supported form factor"
-msgstr ""
+msgstr "Ajout de la mise en page 'mobile'"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:120
 msgid "Fixed: 'Connection Error' dialog not working properly"
 msgstr ""
+"Correction: La boîte de dialogue « Erreur de connexion » ne fonctionnait pas "
+"correctement"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:121
 msgid "Fixed: App might freeze randomly on startup"
 msgstr ""
+"Correction: L'application pouvait se bloquer aléatoirement au démarrage"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:122
 msgid "Changed 'chats' label on sidebar for 'Alpaca'"
-msgstr ""
+msgstr "Changement du titre 'chats' de la barre latéral par 'Alpaga'"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:129
 msgid "Cool Update"
-msgstr ""
+msgstr "Mise à jour sympa"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:131
 msgid "Better design for chat window"
-msgstr ""
+msgstr "Meilleur design pour de fenêtre de discussion"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:132
 msgid "Better design for chat sidebar"
-msgstr ""
+msgstr "Meilleur design pour de la barre latérale"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:133
 msgid "Fixed remote connections"
-msgstr ""
+msgstr "Correction des connexions à distance"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:134
 msgid "Fixed Ollama restarting in loop"
-msgstr ""
+msgstr "Correction d'Ollama qui redémarrait en boucle"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:135
 msgid "Other cool backend stuff"
-msgstr ""
+msgstr "Autres trucs sympas en arrière-plan"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:142
 msgid "Huge Update"
-msgstr ""
+msgstr "Grande mise à jour"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:144
 msgid "Added Ollama as part of Alpaca, Ollama will run in a sandbox"
 msgstr ""
+"Ajout d'Ollama comme partie d'Alpaca, Ollama fonctionnera dans un bac à sable"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:145
 msgid "Added option to connect to remote instances (how it worked before)"
 msgstr ""
+"Ajout de l'option pour se connecter à des instances distantes (comme cela "
+"fonctionnait précédemment)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:146
 msgid "Added option to import and export chats"
-msgstr ""
+msgstr "Ajout de l'option pour importer et exporter les discussions"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:147
 msgid "Added option to run Alpaca with Ollama in the background"
-msgstr ""
+msgstr "Ajout de l'option pour exécuter Alpaga avec Ollama en arrière-plan"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:148
 msgid "Added preferences dialog"
-msgstr ""
+msgstr "Ajout de la boite de dialogue des paramètres"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:149
 msgid "Changed the welcome dialog"
-msgstr ""
+msgstr "Changement de la boite de dialogue de bienvenue"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:151
 #: data/com.jeffser.Alpaca.metainfo.xml.in:168
@@ -256,439 +276,474 @@ msgstr ""
 #: data/com.jeffser.Alpaca.metainfo.xml.in:294
 #: data/com.jeffser.Alpaca.metainfo.xml.in:316
 msgid "Please report any errors to the issues page, thank you."
-msgstr ""
+msgstr "Merci de reporter n'importe quel erreur sur la page des problèmes."
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:159
 msgid "Yet Another Daily Update"
-msgstr ""
+msgstr "Encore une autre mise à jour quotidienne"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:161
 msgid "Added better UI for 'Manage Models' dialog"
 msgstr ""
+"Ajout d'une meilleur interface utilisateur pour la boite de dialogue "
+"'Gestion des modèles'"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:162
 msgid "Added better UI for the chat sidebar"
-msgstr ""
+msgstr "Ajout d'une meilleur interface utilisateur pour la barre latérale"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:163
 msgid ""
 "Replaced model description with a button to open Ollama's website for the "
 "model"
 msgstr ""
+"Remplacement de la description du modèle par un bouton pour ouvrir le site "
+"web Ollama pour le modèle"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:164
 msgid "Added myself to the credits as the spanish translator"
-msgstr ""
+msgstr "Ajout de moi-même aux crédits en tant que traducteur espagnol"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:165
 msgid "Using XDG properly to get config folder"
-msgstr ""
+msgstr "Utilisation de XDG correctement pour avoir un dossier de configuration"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:166
 msgid "Update for translations"
-msgstr ""
+msgstr "Mise à jour concernant les traductions"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:176
 msgid "Quick Fix"
-msgstr ""
+msgstr "Petite correction"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:178
 msgid "The last update had some mistakes in the description of the update"
 msgstr ""
+"La dernière mise à jour avait quelques erreurs dans la description de la "
+"mise à jour"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:188
 msgid "Another Daily Update"
-msgstr ""
+msgstr "Une autre mise à jour quotidienne"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:190
 msgid "Added full Spanish translation"
-msgstr ""
+msgstr "Ajout de la traduction complète Espagnol"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:191
 msgid "Added support for background pulling of multiple models"
 msgstr ""
+"Ajout du support pour le téléchargement de plusieurs modèles en arrière-plan"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:192
 msgid "Added interrupt button"
-msgstr ""
+msgstr "Ajout d'un bouton d'interruptions"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:193
 msgid "Added basic shortcuts"
-msgstr ""
+msgstr "Ajout de raccourcis claviers simples"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:194
 msgid "Better translation support"
-msgstr ""
+msgstr "Meilleur support des traductions"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:195
 msgid ""
 "User can now leave chat name empty when creating a new one, it will add a "
 "placeholder name"
 msgstr ""
+"L'utilisateur peut maintenant quitter une discussion vide quand il en crée "
+"un nouvelle, cela va ajouter un nom de remplacement"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:196
 msgid "Better scalling for different window sizes"
-msgstr ""
+msgstr "Meilleure mise à l'échelle pour différente taille de fenêtre"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:197
 msgid "Fixed: Can't close app if first time setup fails"
 msgstr ""
+"Correction: Impossible de fermer l'application si la première configuration "
+"échouait"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:207
 msgid "Really Big Update"
-msgstr ""
+msgstr "Mise à jour vraiment majeure"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:209
 msgid "Added multiple chats support!"
-msgstr ""
+msgstr "Ajout du support de plusieurs discussions !"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:210
 msgid "Added Pango Markup support (bold, list, title, subtitle, monospace)"
 msgstr ""
+"Ajout du support de Pango Markup (gras, liste, titre, sous-titre, chasse-"
+"fixe)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:211
 msgid "Added autoscroll if the user is at the bottom of the chat"
 msgstr ""
+"Ajout d'un défilement automatique si l'utilisateur est en haut d'une "
+"conersation"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:212
 msgid "Added support for multiple tags on a single model"
-msgstr ""
+msgstr "Ajout du support de plusieurs tag sur un seul modèle"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:213
 msgid "Added better model management dialog"
-msgstr ""
+msgstr "Ajout d'une meilleur boite de dialogue pour la gestion des modèles"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:214
 msgid "Added loading spinner when sending message"
-msgstr ""
+msgstr "Ajout d'un loader lors de m'envoie d'un message"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:215
 msgid "Added notifications if app is not active and a model pull finishes"
 msgstr ""
+"Ajout d'une notification si l'application n'est pas active et que le "
+"téléchargement d'un modèle est terminé"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:216
 msgid "Added new symbolic icon"
-msgstr ""
+msgstr "Ajout de nouveau icônes symboliques"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:217
 msgid "Added frame to message textview widget"
-msgstr ""
+msgstr "Ajout d'un cadre pour le widget des messages"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:218
 msgid "Fixed \"code blocks shouldn't be editable\""
-msgstr ""
+msgstr "Correction 'les blocs de codes ne peuvent pas être édité'"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:228
 #: data/com.jeffser.Alpaca.metainfo.xml.in:285
 msgid "Big Update"
-msgstr ""
+msgstr "Mise à jour majeure"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:230
 msgid "Added code highlighting"
-msgstr ""
+msgstr "Ajout de coloration syntaxique du code"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:231
 msgid "Added image recognition (llava model)"
-msgstr ""
+msgstr "Ajout de la reconnaissance d'image (modèle llava)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:232
 msgid "Added multiline prompt"
-msgstr ""
+msgstr "Ajout des prompts multilignes"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:233
 msgid "Fixed some small bugs"
-msgstr ""
+msgstr "Correction de petits bogues"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:234
 msgid "General optimization"
-msgstr ""
+msgstr "Optimisation générale"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:244
 msgid "Fixes and features"
-msgstr ""
+msgstr "Corrections et fonctionnalités"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:246
 msgid "Russian translation (thanks github/alexkdeveloper)"
-msgstr ""
+msgstr "Traduction Russe (Merci github/alexkdeveloper)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:247
 msgid "Fixed: Cannot close app on first setup"
 msgstr ""
+"Correction: Impossible de fermer l'application lors de la première "
+"installation"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:248
 msgid "Fixed: Brand colors for Flathub"
-msgstr ""
+msgstr "Correction: Couleurs de la marque Flathub"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:249
 msgid "Fixed: App description"
-msgstr ""
+msgstr "Correction: Description de l'application"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:250
 msgid "Fixed: Only show 'save changes dialog' when you actually change the url"
 msgstr ""
+"Correction: N'afficher la boîte de dialogue « enregistrer les modifications "
+"» que lorsque l'url est réellement modifiée"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:260
 msgid "0.2.2 Bug fixes"
-msgstr ""
+msgstr "0.2.2 Corrections de bug"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:262
 msgid "Toast messages appearing behind dialogs"
 msgstr ""
+"Les messages de notifications apparaissaient derrière les boites de dialogue"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:263
 msgid "Local model list not updating when changing servers"
 msgstr ""
+"La liste des modèles locaux n'était pas mise à jour lors d'un changement de "
+"serveur"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:264
 msgid "Closing the setup dialog closes the whole app"
 msgstr ""
+"La fermeture de la boite de dialogue des paramètres fermait toute "
+"l'application"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:274
 msgid "0.2.1 Data saving fix"
-msgstr ""
+msgstr "0.2.1 Correction de la sauvegarde des données"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:275
 msgid ""
 "The app didn't save the config files and chat history to the right "
 "directory, this is now fixed"
 msgstr ""
+"L'application ne sauvegardais pas le fichier de configuration et "
+"l'historique de discussion dans le bon dossier, c'est maintenant corrigé"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:284
 msgid "0.2.0"
-msgstr ""
+msgstr "0.2.0"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:286
 msgid "New Features"
-msgstr ""
+msgstr "Nouvelles fonctionnalités"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:288
 msgid "Restore chat after closing the app"
-msgstr ""
+msgstr "Restaurer la discussion après avoir fermé l'application"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:289
 msgid "A button to clear the chat"
-msgstr ""
+msgstr "Un bouton pour effacer le chat"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:290
 msgid "Fixed multiple bugs involving how messages are shown"
-msgstr ""
+msgstr "Correction de plusieurs bogues concernant l'affichage des messages"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:291
 msgid "Added welcome dialog"
-msgstr ""
+msgstr "Ajout de la boite de dialogue de bienvenue"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:292
 msgid "More stability"
-msgstr ""
+msgstr "Plus de stabilité"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:302
 msgid "0.1.2 Quick fixes"
-msgstr ""
+msgstr "0.1.2 Petites corrections"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:303
 msgid ""
 "This release fixes some metadata needed to have a proper Flatpak application"
 msgstr ""
+"Cette version corrige quelques métadonnées pour avoir une application "
+"Flatpak correct"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:309
 msgid "0.1.1 Stable Release"
-msgstr ""
+msgstr "0.1.1 Version stable"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:310
 msgid "This is the first public version of Alpaca"
-msgstr ""
+msgstr "Ceci est la première version publique d'Alpaga"
 
 #: src/window.py:54 src/window.py:637 src/window.py:639
 msgid "New Chat"
-msgstr ""
+msgstr "Nouvelle discussion"
 
 #: src/window.py:97
 msgid "An error occurred"
-msgstr ""
+msgstr "Une erreur est survenue"
 
 #: src/window.py:98
 msgid "Failed to connect to server"
-msgstr ""
+msgstr "Erreur de connexion au serveur"
 
 #: src/window.py:99
 msgid "Could not list local models"
-msgstr ""
+msgstr "Impossible de lister les modèles locaux"
 
 #: src/window.py:100
 msgid "Could not delete model"
-msgstr ""
+msgstr "Impossible de supprimer le modèle"
 
 #: src/window.py:101
 msgid "Could not pull model"
-msgstr ""
+msgstr "Impossible de télécharger le modèle"
 
 #: src/window.py:102
 msgid "Cannot open image"
-msgstr ""
+msgstr "Impossible d'ouvrir l'image"
 
 #: src/window.py:103
 msgid "Cannot delete chat because it's the only one left"
 msgstr ""
+"Vous ne pouvez pas supprimer la discussion car c'est la seule qui reste"
 
 #: src/window.py:104
 msgid "There was an error with the local Ollama instance, so it has been reset"
 msgstr ""
+"Une erreur est survenue avec l'instance local d'Ollama, elle a donc été "
+"reinitialisée"
 
 #: src/window.py:107
 msgid "Please select a model before chatting"
-msgstr ""
+msgstr "Merci de sélectionner un modèle avant de discuter"
 
 #: src/window.py:108
 msgid "Chat cannot be cleared while receiving a message"
 msgstr ""
+"La discussion ne peut pas être supprimé pendant la réception d'un message"
 
 #: src/window.py:109
 msgid "That tag is already being pulled"
-msgstr ""
+msgstr "Ce tag est déjà en train d'être téléchargé"
 
 #: src/window.py:110
 msgid "That tag has been pulled already"
-msgstr ""
+msgstr "Ce tag à déjà été télécharger"
 
 #: src/window.py:111
 msgid "Code copied to the clipboard"
-msgstr ""
+msgstr "Code copié dans le presse-papier"
 
 #: src/window.py:114
 msgid "Model deleted successfully"
-msgstr ""
+msgstr "Modèle supprimé avec succès"
 
 #: src/window.py:115
 msgid "Model pulled successfully"
-msgstr ""
+msgstr "Modèle téléchargé avec succès"
 
 #: src/window.py:116
 msgid "Chat exported successfully"
-msgstr ""
+msgstr "Discussion exportée avec succès"
 
 #: src/window.py:117
 msgid "Chat imported successfully"
-msgstr ""
+msgstr "Discussion importée avec succès"
 
 #: src/window.py:129
 msgid "Upload image"
-msgstr ""
+msgstr "Charger une image"
 
 #: src/window.py:133 src/window.ui:231
 msgid "Only available on selected models"
-msgstr ""
+msgstr "Seulement disponible sur les modèles sélectionnés"
 
 #: src/window.py:197
 msgid "Close"
-msgstr ""
+msgstr "Fermer"
 
 #: src/window.py:198 src/window.ui:393
 msgid "Next"
-msgstr ""
+msgstr "Suivant"
 
 #: src/window.py:245
 msgid "Pulling in the background..."
-msgstr ""
+msgstr "Téléchargement en arrière-plan..."
 
 #: src/window.py:555
 msgid "Task Complete"
-msgstr ""
+msgstr "Tache terminée"
 
 #: src/window.py:555
 msgid "Model '{}' pulled successfully."
-msgstr ""
+msgstr "Modèle '{}' téléchargé avec succès."
 
 #: src/window.py:560
 msgid "Pull Model Error"
-msgstr ""
+msgstr "Erreur de téléchargement du modèle"
 
 #: src/window.py:560
 msgid "Failed to pull model '{}' due to network error."
 msgstr ""
+"Échec du téléchargement du modèle '{}' à cause d'une erreur de connexion."
 
 #: src/window.ui:38
 msgid "New chat"
-msgstr ""
+msgstr "Nouvelle discussion"
 
 #: src/window.ui:47
 msgid "Import chat"
-msgstr ""
+msgstr "Importer la discussion"
 
 #: src/window.ui:56
 msgid "Export chat"
-msgstr ""
+msgstr "Exporter la discussion"
 
 #: src/window.ui:89
 msgid "Toggle Sidebar"
-msgstr ""
+msgstr "Basculer la barre latérale"
 
 #: src/window.ui:112 src/window.ui:308
 msgid "Manage models"
-msgstr ""
+msgstr "Gérer les modèles"
 
 #: src/window.ui:126
 msgid "Menu"
-msgstr ""
+msgstr "Menu"
 
 #: src/window.ui:221
 msgid "Send"
-msgstr ""
+msgstr "Envoyer"
 
 #: src/window.ui:234
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 #: src/window.ui:258 src/window.ui:546 src/window.ui:604
 msgid "Preferences"
-msgstr ""
+msgstr "Paramètres"
 
 #: src/window.ui:261 src/window.ui:588
 msgid "General"
-msgstr ""
+msgstr "Général"
 
 #: src/window.ui:265
 msgid "Remote Connection"
-msgstr ""
+msgstr "Connexion à distance"
 
 #: src/window.ui:266
 msgid "Manage a remote connection to Ollama"
-msgstr ""
+msgstr "Gérer une connexion à distance d'Ollama"
 
 #: src/window.ui:269
 msgid "Use remote connection"
-msgstr ""
+msgstr "Utiliser une connexion à distance"
 
 #: src/window.ui:275
 msgid "URL of remote instance"
-msgstr ""
+msgstr "URL de l'instance distante"
 
 #: src/window.ui:283
 msgid "Behavior"
-msgstr ""
+msgstr "Comportement"
 
 #: src/window.ui:284
 msgid "Manage Alpaca's Behavior"
-msgstr ""
+msgstr "Gérer le comportement d'Alpaga"
 
 #: src/window.ui:287
 msgid "Run in background"
-msgstr ""
+msgstr "Exécution en arrière-plan"
 
 #: src/window.ui:377
 msgid "Previous"
-msgstr ""
+msgstr "Précédent"
 
 #: src/window.ui:420
 msgid "Welcome to Alpaca"
-msgstr ""
+msgstr "Bienvenue sur Alpaga"
 
 #: src/window.ui:421
 msgid "Powered by Ollama"
-msgstr ""
+msgstr "Fonctionne grâce à Ollama"
 
 #: src/window.ui:424
 msgid "Ollama Website"
-msgstr ""
+msgstr "Site web d'Ollama"
 
 #: src/window.ui:441
 msgid ""
@@ -696,10 +751,14 @@ msgid ""
 "software resulting from the execution of code generated by an AI model. "
 "Please exercise caution and review the code carefully before running it."
 msgstr ""
+"Alpaga et ses développeurs ne sont pas responsables des dommages causés à "
+"votre appareil ou vos logiciels lors de l'exécution de code généré par les "
+"modèles d'IA. Merci de faire attention et de relire attentivement le code "
+"avant de l'exécuter."
 
 #: src/window.ui:452
 msgid "Featured Models"
-msgstr ""
+msgstr "Modèles recommandés"
 
 #: src/window.ui:453
 msgid ""
@@ -707,67 +766,70 @@ msgid ""
 "model, you can either pull models from this list or the 'Manage Models' menu "
 "later."
 msgstr ""
+"Alpaga fonctionne localement sur votre ordinateur, pour commencer à discuter "
+"vous aurez besoin d'un modèle d'IA, vous pouvez télécharger un modèle soit "
+"depuis cette liste soit depuis le menu 'Gérer les modèles' plus tard."
 
 #: src/window.ui:463
 msgid "Built by Meta"
-msgstr ""
+msgstr "Développé par Meta"
 
 #: src/window.ui:480
 msgid "Built by Google DeepMind"
-msgstr ""
+msgstr "Développé par Google DeepMind"
 
 #: src/window.ui:497
 msgid "Built by Microsoft"
-msgstr ""
+msgstr "Développé par Microsoft"
 
 #: src/window.ui:514
 msgid "Multimodal AI with image recognition"
-msgstr ""
+msgstr "IA multimodale avec reconnaissance d'image"
 
 #: src/window.ui:542
 msgid "Clear Chat"
-msgstr ""
+msgstr "Supprimer la conversation"
 
 #: src/window.ui:550
 msgid "Keyboard Shortcuts"
-msgstr ""
+msgstr "Raccourcis claviers"
 
 #: src/window.ui:554
 msgid "About Alpaca"
-msgstr ""
+msgstr "À propos d'Alpaga"
 
 #: src/window.ui:562
 msgid "Remove"
-msgstr ""
+msgstr "Supprimer"
 
 #: src/window.ui:592
 msgid "Close application"
-msgstr ""
+msgstr "Fermer l'application"
 
 #: src/window.ui:598
 msgid "Clear chat"
-msgstr ""
+msgstr "Supprimer la conversation"
 
 #: src/window.ui:610
 msgid "Show shortcuts window"
-msgstr ""
+msgstr "Voir les raccourcis clavier"
 
 #: src/window.ui:617
 msgid "Editor"
-msgstr ""
+msgstr "Éditeur"
 
 #: src/window.ui:621
 msgid "Copy"
-msgstr ""
+msgstr "Copier"
 
 #: src/window.ui:627
 msgid "Paste"
-msgstr ""
+msgstr "Coller"
 
 #: src/window.ui:633
 msgid "Insert new line"
-msgstr ""
+msgstr "Ajouter un ligne"
 
 #: src/window.ui:639
 msgid "Send Message"
-msgstr ""
+msgstr "Envoyer le message"


### PR DESCRIPTION
# French translation for Alpaca

### Translate guideline

| English	| French	|
|----------|-----------|
| Alpaca	| Alpaga	|
| to chat	| discuter |
| a chat	| une discussion |

Translation harmonized except changelogs (because the original changelogs aren't harmonized)