### PR TITLE
Put the primary menu in the sidebar and the chat actions in the chat view header

### DIFF
--- a/src/window.ui
+++ b/src/window.ui
@@ -46,11 +46,11 @@
                       </object>
                     </child>
                     <child type="end">
-                      <object class="GtkMenuButton" id="chats_menu_button">
-                        <property name="direction">1</property>
-                        <property name="halign">3</property>
-                        <property name="menu-model">chats_menu</property>
-                        <property name="icon-name">view-more-symbolic</property>
+                      <object class="GtkMenuButton">
+                        <property name="primary">True</property>
+                        <property name="icon-name">open-menu-symbolic</property>
+                        <property name="tooltip-text" translatable="yes">Menu</property>
+                        <property name="menu-model">primary_menu</property>
                       </object>
                     </child>
                   </object>
@@ -113,11 +113,11 @@
                       </object>
                     </property>
                     <child type="end">
-                      <object class="GtkMenuButton">
-                        <property name="primary">True</property>
-                        <property name="icon-name">open-menu-symbolic</property>
-                        <property name="tooltip-text" translatable="yes">Menu</property>
-                        <property name="menu-model">primary_menu</property>
+                      <object class="GtkMenuButton" id="chats_menu_button">
+                        <property name="direction">1</property>
+                        <property name="halign">3</property>
+                        <property name="menu-model">chats_menu</property>
+                        <property name="icon-name">view-more-symbolic</property>
                       </object>
                     </child>
                   </object>
@@ -860,10 +860,6 @@
   <menu id="primary_menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">Clear Chat</attribute>
-        <attribute name="action">app.clear</attribute>
-      </item>
-      <item>
         <attribute name="label" translatable="yes">Preferences</attribute>
         <attribute name="action">app.preferences</attribute>
       </item>
@@ -879,6 +875,10 @@
   </menu>
   <menu id="chats_menu">
     <section>
+      <item>
+        <attribute name="label" translatable="yes">Clear Chat</attribute>
+        <attribute name="action">app.clear</attribute>
+      </item>
       <item>
         <attribute name="label" translatable="yes">Export current chat</attribute>
         <attribute name="action">app.export_current_chat</attribute>

--- a/src/window.ui
+++ b/src/window.ui
@@ -860,6 +860,12 @@
   <menu id="primary_menu">
     <section>
       <item>
+        <attribute name="label" translatable="yes">Import chat</attribute>
+        <attribute name="action">app.import_chat</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
         <attribute name="label" translatable="yes">Preferences</attribute>
         <attribute name="action">app.preferences</attribute>
       </item>
@@ -882,10 +888,6 @@
       <item>
         <attribute name="label" translatable="yes">Export current chat</attribute>
         <attribute name="action">app.export_current_chat</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">Import chat</attribute>
-        <attribute name="action">app.import_chat</attribute>
       </item>
     </section>
   </menu>


### PR DESCRIPTION
Moves primary menu in the sidebar and the chat actions menu in the chat window.

I think it makes more sense to have chat actions in the chat window header rather than the sidebar. You usually find the primary menu in sidebars if the app has one, but not always, depending on the situation.

I also moved the "Clear Chat" option in the chat actions menu for the same reason.