### PR TITLE
Fixed formatting conflicts

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -325,8 +325,8 @@ msgid "Reverted back to standard styles"
 msgstr "Zu Standardstilen zurückgekehrt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:169
-msgid "Fixed generated titles having '\'S' for some reason"
-msgstr "Generierte Titel haben aus irgendeinem Grund '\'S' - behoben"
+msgid "Fixed generated titles having '\"S' for some reason"
+msgstr "Generierte Titel haben aus irgendeinem Grund '\"S' - behoben"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:170
 msgid "Changed min width for model dropdown"

--- a/po/de.po
+++ b/po/de.po
@@ -325,7 +325,7 @@ msgid "Reverted back to standard styles"
 msgstr "Zu Standardstilen zurückgekehrt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:169
-msgid "Fixed generated titles having "'S" for some reason"
+msgid "Fixed generated titles having '\'S' for some reason"
 msgstr "Generierte Titel haben aus irgendeinem Grund '\'S' - behoben"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:170

--- a/po/de.po
+++ b/po/de.po
@@ -147,7 +147,7 @@ msgstr "Ladeanimation beim erneuten Generieren einer Nachricht hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:91
 msgid "Added Ollama debugging to 'About Alpaca' dialog"
-msgstr "Ollama-Debugging zum "Über Alpaca"-Dialog hinzugefügt"
+msgstr "Ollama-Debugging zum 'Über Alpaca'-Dialog hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:92
 msgid "Changed YouTube transcription dialog appearance and behavior"
@@ -170,7 +170,7 @@ msgstr "STRG+W und STRG+Q stoppen die lokale Instanz vor dem Schließen der App"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:97
 msgid "Changed appearance of 'Open Model Manager' button on welcome screen"
-msgstr "Erscheinungsbild der Schaltfläche "Modell-Manager öffnen" auf dem Begrüßungsbildschirm geändert"
+msgstr "Erscheinungsbild der Schaltfläche 'Modell-Manager öffnen' auf dem Begrüßungsbildschirm geändert"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:98
 msgid "Fixed message generation not working consistently"
@@ -186,7 +186,7 @@ msgstr "Modell-Manager öffnet sich schneller"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:109
 msgid "Delete chat option in secondary menu"
-msgstr "Option "Chat löschen" im sekundären Menü"
+msgstr "Option 'Chat löschen' im sekundären Menü"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:110
 msgid "New model selector popup"
@@ -234,7 +234,7 @@ msgstr "Nachrichtengenerator repariert"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:124
 msgid "Removed 'Featured models' from welcome dialog"
-msgstr ""Empfohlene Modelle" aus dem Begrüßungsdialog entfernt"
+msgstr "'Empfohlene Modelle' aus dem Begrüßungsdialog entfernt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:125
 msgid "Added default buttons to dialogs"
@@ -246,7 +246,7 @@ msgstr "Import/Export von Chats behoben"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:127
 msgid "Changed Python2 title to Python on code blocks"
-msgstr "Titel "Python2" in Codeblöcken zu "Python" geändert"
+msgstr "Titel 'Python2' in Codeblöcken zu 'Python' geändert"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:128
 msgid ""
@@ -268,7 +268,7 @@ msgstr "Tastenkombinationen auf Standards geändert"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:140
 msgid "Moved 'Manage Models' button to primary menu"
-msgstr "Schaltfläche „Modelle verwalten" in das Hauptmenü verschoben"
+msgstr "Schaltfläche 'Modelle verwalten' in das Hauptmenü verschoben"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:141
 #: data/com.jeffser.Alpaca.metainfo.xml.in:163
@@ -326,7 +326,7 @@ msgstr "Zu Standardstilen zurückgekehrt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:169
 msgid "Fixed generated titles having "'S" for some reason"
-msgstr "Generierte Titel haben aus irgendeinem Grund "'S" - behoben"
+msgstr "Generierte Titel haben aus irgendeinem Grund '\'S' - behoben"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:170
 msgid "Changed min width for model dropdown"
@@ -661,7 +661,7 @@ msgstr "Kompatibilität für DOCX hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:310
 msgid "Merged 'file attachment' menu into one button"
-msgstr "Menü „Dateianhang" in eine Schaltfläche zusammengeführt"
+msgstr "Menü 'Dateianhang' in eine Schaltfläche zusammengeführt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:317
 #: data/com.jeffser.Alpaca.metainfo.xml.in:510
@@ -731,7 +731,7 @@ msgstr "Export-/Import-Chat-Schaltflächen in ein Menü zusammengefasst"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:361
 msgid "Added 'model tweaks' (temperature, seed, keep_alive)"
-msgstr "„Modellanpassungen" (Temperatur, Seed, Keep_Alive) hinzugefügt"
+msgstr "'Modellanpassungen' (Temperatur, Seed, Keep_Alive) hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:362
 msgid "Fixed send / stop button"
@@ -807,7 +807,7 @@ msgstr "Behoben: Inhalt ändert sich nicht beim Erstellen eines neuen Chats"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:407
 msgid "Added 'Featured Models' page on welcome dialog"
-msgstr "Seite „Empfohlene Modelle" im Begrüßungsdialog hinzugefügt"
+msgstr "Seite 'Empfohlene Modelle' im Begrüßungsdialog hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:414
 msgid "Nice Update"
@@ -855,7 +855,7 @@ msgstr "Allgemeine Benutzeroberfläche verfeinert (Danke Nokse22)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:441
 msgid "Added 'delete message' feature"
-msgstr "Funktion "Nachricht löschen" hinzugefügt"
+msgstr "Funktion 'Nachricht löschen' hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:442
 msgid ""
@@ -870,7 +870,7 @@ msgid ""
 "Changed 'send' shortcut to just the return/enter key (to add a new line use "
 "shift+return)"
 msgstr ""
-""Senden"-Verknüpfung auf die Eingabetaste geändert (für einen Zeilenumbruch "
+"'Senden'-Verknüpfung auf die Eingabetaste geändert (für einen Zeilenumbruch "
 "Umschalttaste+Eingabetaste verwenden)"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:450
@@ -883,11 +883,11 @@ msgstr "Behoben: Kleiner Rechtschreibfehler"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:453
 msgid "Added 'mobile' as a supported form factor"
-msgstr ""Mobil" als unterstützten Formfaktor hinzugefügt"
+msgstr "'Mobil' als unterstützten Formfaktor hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:454
 msgid "Fixed: 'Connection Error' dialog not working properly"
-msgstr "Behoben: Dialog "Verbindungsfehler" funktioniert nicht richtig"
+msgstr "Behoben: Dialog 'Verbindungsfehler' funktioniert nicht richtig"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:455
 msgid "Fixed: App might freeze randomly on startup"
@@ -895,7 +895,7 @@ msgstr "Behoben: App kann beim Start zufällig einfrieren"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:456
 msgid "Changed 'chats' label on sidebar for 'Alpaca'"
-msgstr "Bezeichnung "Chats" in der Seitenleiste in "Alpaca" geändert"
+msgstr "Bezeichnung 'Chats' in der Seitenleiste in 'Alpaca' geändert"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:463
 msgid "Cool Update"
@@ -965,7 +965,7 @@ msgstr "Noch ein tägliches Update"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:495
 msgid "Added better UI for 'Manage Models' dialog"
-msgstr "Bessere Benutzeroberfläche für den Dialog "Modelle verwalten" hinzugefügt"
+msgstr "Bessere Benutzeroberfläche für den Dialog 'Modelle verwalten' hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:496
 msgid "Added better UI for the chat sidebar"
@@ -1076,8 +1076,8 @@ msgid "Added frame to message textview widget"
 msgstr "Rahmen zum Nachrichten-Textansichts-Widget hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:552
-msgid "Fixed "code blocks shouldn't be editable""
-msgstr "Behoben: "Codeblöcke sollten nicht editierbar sein""
+msgid "Fixed 'code blocks shouldnt be editable'"
+msgstr "Behoben: 'Codeblöcke sollten nicht editierbar sein'"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:564
 msgid "Added code highlighting"
@@ -1121,7 +1121,7 @@ msgstr "Behoben: App-Beschreibung"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:584
 msgid "Fixed: Only show 'save changes dialog' when you actually change the url"
-msgstr "Behoben: Dialog "Änderungen speichern" nur anzeigen, wenn die URL tatsächlich geändert wurde"
+msgstr "Behoben: Dialog 'Änderungen speichern' nur anzeigen, wenn die URL tatsächlich geändert wurde"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:594
 msgid "0.2.2 Bug fixes"


### PR DESCRIPTION
No more errors are thrown when starting the “update_translation_files.sh” in relation to the de.po file.
Reason: My previous string formatting was incorrect
FIXED. #265 