### PR TITLE
Add keywords to .desktop file

### DIFF
--- a/data/com.jeffser.Alpaca.desktop.in
+++ b/data/com.jeffser.Alpaca.desktop.in
@@ -5,5 +5,6 @@ Icon=com.jeffser.Alpaca
 Terminal=false
 Type=Application
 Categories=Utility;Development;Chat;
+Keywords=ai;ollama;gpt
 StartupNotify=true
 X-Purism-FormFactor=Workstation;Mobile;

--- a/data/com.jeffser.Alpaca.desktop.in
+++ b/data/com.jeffser.Alpaca.desktop.in
@@ -5,6 +5,6 @@ Icon=com.jeffser.Alpaca
 Terminal=false
 Type=Application
 Categories=Utility;Development;Chat;
-Keywords=ai;ollama;gpt
+Keywords=ai;ollama;llm
 StartupNotify=true
 X-Purism-FormFactor=Workstation;Mobile;


### PR DESCRIPTION
<!--Please be aware that GNOME Code of Conduct applies to Alpaca, https://conduct.gnome.org/-->
**Is your feature request related to a problem? Please describe.**
Sometimes I've been searching for this app but forgotten the name. Scrolling through gnome's app menu to find it would take a while with the number of things I have installed so it'd be nice to be able to search for it.

**Describe the solution you'd like**
Add some keywords (eg ai, ollama, gpt) to the .desktop file

**Describe alternatives you've considered**
Not adding them 🤷🏻 

I know that the contributing guidelines say to open an issue before contributing to make sure there' no overlapping work but given the size of this change I think you can understand why that's not necessary
