### PR TITLE
Add an option to hide the power save warning at startup

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -905,8 +905,8 @@ Generate a title following these rules:
             threading.Thread(target=self.prepare_alpaca, args=(11435, '', False, {'temperature': 0.7, 'seed': 0, 'keep_alive': 5}, {}, '', 0, True, False)).start()
             self.welcome_dialog.present(self)
 
-    if self.powersaver_warning.get_active():
-        self.banner.set_revealed(Gio.PowerProfileMonitor.dup_default().get_power_saver_enabled())
-        
-    Gio.PowerProfileMonitor.dup_default().connect("notify::power-saver-enabled", lambda monitor, *_: self.power_saver_toggled(monitor))
-    self.banner.connect('button-clicked', lambda *_: self.banner.set_revealed(False))
+        if self.powersaver_warning.get_active():
+            self.banner.set_revealed(Gio.PowerProfileMonitor.dup_default().get_power_saver_enabled())
+            
+        Gio.PowerProfileMonitor.dup_default().connect("notify::power-saver-enabled", lambda monitor, *_: self.power_saver_toggled(monitor))
+        self.banner.connect('button-clicked', lambda *_: self.banner.set_revealed(False))

--- a/src/window.py
+++ b/src/window.py
@@ -904,8 +904,10 @@ Generate a title following these rules:
             except Exception as e:
                 logger.error(e)
                 threading.Thread(target=self.prepare_alpaca, args=(11435, '', False, {'temperature': 0.7, 'seed': 0, 'keep_alive': 5}, {}, '', 0, True, True)).start()
+                self.powersaver_warning_switch.set_active(True)
         else:
             threading.Thread(target=self.prepare_alpaca, args=(11435, '', False, {'temperature': 0.7, 'seed': 0, 'keep_alive': 5}, {}, '', 0, True, False)).start()
+            self.powersaver_warning_switch.set_active(True)
             self.welcome_dialog.present(self)
 
         if self.powersaver_warning_switch.get_active():

--- a/src/window.py
+++ b/src/window.py
@@ -905,7 +905,7 @@ Generate a title following these rules:
             threading.Thread(target=self.prepare_alpaca, args=(11435, '', False, {'temperature': 0.7, 'seed': 0, 'keep_alive': 5}, {}, '', 0, True, False)).start()
             self.welcome_dialog.present(self)
 
-        if self.powersaver_warning.get_active():
+        if self.powersaver_warning_switch.get_active():
             self.banner.set_revealed(Gio.PowerProfileMonitor.dup_default().get_power_saver_enabled())
             
         Gio.PowerProfileMonitor.dup_default().connect("notify::power-saver-enabled", lambda monitor, *_: self.power_saver_toggled(monitor))

--- a/src/window.py
+++ b/src/window.py
@@ -258,7 +258,10 @@ class AlpacaWindow(Adw.ApplicationWindow):
     @Gtk.Template.Callback()
     def switch_powersaver_warning(self, switch, user_data):
         logger.debug("Switching powersaver warning banner")
-        
+        if switch.get_active():
+            self.banner.set_revealed(Gio.PowerProfileMonitor.dup_default().get_power_saver_enabled())
+        else:
+            self.banner.set_revealed(False)
         self.save_server_config()
 
     @Gtk.Template.Callback()

--- a/src/window.ui
+++ b/src/window.ui
@@ -263,6 +263,12 @@
                   <property name="title" translatable="yes">Run Alpaca In Background</property>
                 </object>
               </child>
+              <child>
+                <object class="AdwSwitchRow" id="omit_powersave_warning_switch">
+                  <signal name="notify::active" handler="switch_omit_powersave_warning"/>
+                  <property name="title" translatable="yes">Do not show powersave warning banner upon startup</property>
+                </object>
+              </child>
             </object>
           </child>
           <child>

--- a/src/window.ui
+++ b/src/window.ui
@@ -264,9 +264,9 @@
                 </object>
               </child>
               <child>
-                <object class="AdwSwitchRow" id="omit_powersave_warning_switch">
-                  <signal name="notify::active" handler="switch_omit_powersave_warning"/>
-                  <property name="title" translatable="yes">Do not show powersave warning banner upon startup</property>
+                <object class="AdwSwitchRow" id="powersaver_warning_switch">
+                  <signal name="notify::active" handler="switch_powersaver_warning"/>
+                  <property name="title" translatable="yes">Show Power Saver Warning</property>
                 </object>
               </child>
             </object>


### PR DESCRIPTION
Hello again @Jeffser, here is the pull request without translation files.

I added an option mostly for laptop users to allow omitting the power saver warning at startup because it might get annoying for some people.

For context, many users are regularly using power saver for long periods of time to get longer battery life on mobile devices. This patch gives them the option to not get warned about the very thing they're aware of everytime they use Alpaca:

![image](https://github.com/user-attachments/assets/40ba5553-77fb-4433-8191-5199092dd318)

Hope I could help!