### PR TITLE
made font family of code blocks monospace

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -34,3 +34,6 @@ stacksidebar {
 .image_recognition_indicator {
   padding: 0px 10px;
 }
+.code_block {
+  font-family: monospace;
+}


### PR DESCRIPTION
Hello,

this pull request changes the formatting (more specifically the font family) of the code blocks inside Alpaca chats. It changes it from the standard font to monospace:

![image](https://github.com/user-attachments/assets/cbaa34e8-2636-4dd6-8727-49c4d8b8ea23)

This makes it a lot easier to read and often is standard for rendering code.

Hope this helps, even though it's just a small change! :)
