### PR TITLE
Use show API to detect vision.

### DIFF
--- a/src/custom_widgets/model_widget.py
+++ b/src/custom_widgets/model_widget.py
@@ -415,7 +415,7 @@ class model_manager_container(Gtk.Box):
             spacing=12,
             orientation=1
         )
-        self.model_vision_cache = {}
+        
         self.pulling_list = pulling_model_list()
         self.append(self.pulling_list)
         self.local_list = local_model_list()
@@ -485,10 +485,6 @@ class model_manager_container(Gtk.Box):
         self.model_selector.change_model(model_name)
 
     def has_vision(self, model_name) -> bool:
-        if model_name in self.model_vision_cache:
-            logger.debug(f"Vision for {model_name} (cached): {self.model_vision_cache[model_name]}")
-            return self.model_vision_cache[model_name]
-
         response = (
             window.ollama_instance.request(
                 "POST", "api/show", json.dumps({"name": model_name})
@@ -501,9 +497,8 @@ class model_manager_container(Gtk.Box):
 
         try:
             model_info = json.loads(response.text)
-            self.model_vision_cache[model_name] = 'projector_info' in model_info
-            logger.debug(f"Vision for {model_name}: {self.model_vision_cache[model_name]}")
-            return self.model_vision_cache[model_name]
+            logger.debug(f"Vision for {model_name}: {'projector_info' in model_info}")
+            return 'projector_info' in model_info
         except Exception as e:
             logger.error(f"Error fetching vision info: {str(e)}")
             return False

--- a/src/custom_widgets/model_widget.py
+++ b/src/custom_widgets/model_widget.py
@@ -483,11 +483,29 @@ class model_manager_container(Gtk.Box):
     def change_model(self, model_name:str):
         self.model_selector.change_model(model_name)
 
+    def has_vision(model_name) -> bool:
+        response = (
+            window.ollama_instance.request(
+                "POST", "api/show", json.dumps({"model": model_name})
+            )
+        )
+
+        if response.status_code != 200:
+            return False
+
+        return 'projector_info' in response
+
     def verify_if_image_can_be_used(self):
         logger.debug("Verifying if image can be used")
         selected = self.get_selected_model()
         if selected == None:
             return False
+
+        # first try ollama show API.
+        if has_vision(selected):
+            return True
+
+        # then fall back to the old method.
         selected = selected.split(":")[0]
         with open(os.path.join(source_dir, 'available_models.json'), 'r', encoding="utf-8") as f:
             if selected in [key for key, value in json.load(f).items() if value["image"]]:
@@ -532,4 +550,3 @@ class model_manager_container(Gtk.Box):
             GLib.idle_add(window.chat_list_box.update_welcome_screens, len(self.get_model_list()) > 0)
             if len(list(self.pulling_list)) == 0:
                 GLib.idle_add(self.pulling_list.set_visible, False)
-


### PR DESCRIPTION
Instead of relying on a file of available models, prefer the ollama show API to detect vision capabilities.

I need to test this. Every time I run `meson compile`, the resulting executable python script thingy complains about a missing gresource at `/usr/local/share/Alpaca`, and if I shove the file in there, it complains about missing `pypdf`. How do you normally test? Is there a development setup guide?