### PR TITLE
Extend security policy to reflect where to disclose vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,10 @@
 # Security Policy
 
-## Supported Packaging
+## Supported Packaging and distribution methods
 
 Alpaca only supports [Flatpak](https://flatpak.org/) packaging officially, any other packaging methods might not behave as expected.
+Thus, official security-related support is only provided to the Flatpak distribution as of right now.
+This may be subject to change in the future.
 
 ## Official Versions
 
@@ -10,3 +12,14 @@ The only ways Alpaca is being distributed officially are:
 
 - [Alpaca's GitHub Repository Releases Page](https://github.com/Jeffser/Alpaca/releases)
 - [Flathub](https://flathub.org/apps/com.jeffser.Alpaca)
+
+## Where to report critical security vulnerabilities
+
+As Alpaca is a public project with several thousands of users, it's extremely vital to keep it secure.
+Flatpak confines it already due to sandboxing mechanisms, but nothing is bulletproof.
+
+If you believe to have found a critical security vulnerability, **DO NOT** disclose it publicly immediately.
+Allow for it to be patched first and **use the contact methods listed in the maintainer's profile** ([Jeffser](https://github.com/Jeffser))
+to disclose any vulnerability privately.
+
+Thank you in advance!

--- a/src/main.py
+++ b/src/main.py
@@ -55,10 +55,10 @@ translators = [
     'YusaBecerikli (Turkish) https://github.com/YusaBecerikli',
     'Simon (Ukrainian) https://github.com/OriginalSimon',
     'Marcel Margenberg (German) https://github.com/MehrzweckMandala',
-    'Mags0ft (German) https://github.com/mags0ft'
+    'Magnus Schlinsog (German) https://github.com/mags0ft',
     'Edoardo Brogiolo (Italian) https://github.com/edo0',
     'Shidore (Japanese) https://github.com/sh1d0re',
-    'Henk Leerssen (Dutch) https://github.com/Henkster72'
+    'Henk Leerssen (Dutch) https://github.com/Henkster72',
 ]
 
 parser = argparse.ArgumentParser(description="Alpaca")


### PR DESCRIPTION
Good day,

I've noticed that the current security policy is not very clear about what to do in case of a found vulnerability.
This pull request fixes said issue (#528 can be closed then, too).

Best regards