### PR TITLE
Add support for OpenAI API

### DIFF
--- a/src/instance_manager.py
+++ b/src/instance_manager.py
@@ -1,13 +1,39 @@
 # instance_manager.py
 """
-Manages AI instances (only Ollama for now)
+Manages AI instances (Ollama, OpenAI)
 """
 
 import openai
+import requests
 
 class instance:
 
-    def __init__(self, instance_url:str='http://0.0.0.0:11434', instance_key:str=''):
+    def __init__(self, instance_url:str='http://0.0.0.0:11434', instance_key:str='', api_type:str='ollama'):
         self.instance_url = instance_url
         self.instance_key = instance_key
+        self.api_type = api_type
 
+    def request(self, connection_type:str, connection_url:str, data:dict=None, callback:callable=None) -> requests.models.Response:
+        headers = self.get_headers()
+        response = None
+        if connection_type == "GET":
+            response = requests.get(connection_url, headers=headers)
+        elif connection_type == "POST":
+            if callback:
+                response = requests.post(connection_url, headers=headers, data=data, stream=True)
+                if response.status_code == 200:
+                    for line in response.iter_lines():
+                        if line:
+                            callback(json.loads(line.decode("utf-8")))
+            else:
+                response = requests.post(connection_url, headers=headers, data=data, stream=False)
+        elif connection_type == "DELETE":
+            response = requests.delete(connection_url, headers=headers, data=data)
+        return response
+
+    def get_headers(self) -> dict:
+        headers = {}
+        if self.api_type == 'openai':
+            headers["Authorization"] = f"Bearer {self.instance_key}"
+            headers["Content-Type"] = "application/json"
+        return headers

--- a/src/main.py
+++ b/src/main.py
@@ -184,6 +184,8 @@ def main(version):
     parser.add_argument('--select-chat', type=str, metavar='"CHAT"', help="Select a chat on launch")
     parser.add_argument('--ask', type=str, metavar='"MESSAGE"', help="Open quick ask with message")
     parser.add_argument('--change-port', type=int, metavar='"PORT"', help="Change the integrated instance port")
+    parser.add_argument('--api-type', type=str, metavar='"API_TYPE"', help="Specify the API type (ollama, openai, gemini, anthropic")
+    parser.add_argument('--api-key', type=str, metavar='"API_KEY"', help="Specify the API key for the chosen API type")
     args = parser.parse_args()
 
     if args.version:
@@ -213,6 +215,14 @@ def main(version):
         sqlite_con = sqlite3.connect(os.path.join(data_dir, "alpaca.db"))
         cursor = sqlite_con.cursor()
         cursor.execute("UPDATE preferences SET value=? WHERE id=?", (args.change_port, 'local_port'))
+        sqlite_con.commit()
+        sqlite_con.close()
+
+    if args.api_type and args.api_key:
+        sqlite_con = sqlite3.connect(os.path.join(data_dir, "alpaca.db"))
+        cursor = sqlite_con.cursor()
+        cursor.execute("UPDATE preferences SET value=? WHERE id=?", (args.api_type, 'api_type'))
+        cursor.execute("UPDATE preferences SET value=? WHERE id=?", (args.api_key, 'api_key'))
         sqlite_con.commit()
         sqlite_con.close()
 

--- a/src/window.py
+++ b/src/window.py
@@ -834,7 +834,7 @@ Generate a title following these rules:
     def attach_file(self, file_path, file_type):
         logger.debug(f"Attaching file: {file_path}")
         file_name = self.generate_numbered_name(os.path.basename(file_path), self.attachments.keys())
-        content = self.get_content_of_file(file_path, file_type)
+        content = self.get_content_of_file(file_path)
         if content:
             button_content = Adw.ButtonContent(
                 label=file_name,


### PR DESCRIPTION
Add support for OpenAI API integration.

* **`src/instance_manager.py`**:
  - Add support for OpenAI API.
  - Update the `instance` class to handle OpenAI API.
  - Add `request` method to handle different connection types (GET, POST, DELETE).
  - Add `get_headers` method to set headers for OpenAI API.

* **`src/window.py`**:
  - Update `attach_file` method to remove `file_type` parameter.

* **`src/main.py`**:
  - Add command-line arguments `--api-type` and `--api-key` to specify API type and key.
  - Update database preferences with API type and key if provided.

