### PR TITLE
Use human-like counting starting from 1 instead of 0 for imported document pages

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -789,7 +789,7 @@ Generate a title following these rules:
                 return None
             text = ""
             for i, page in enumerate(reader.pages):
-                text += f"\n- Page {i}\n{page.extract_text(extraction_mode='layout', layout_mode_space_vertically=False)}\n"
+                text += f"\n- Page {i+1}\n{page.extract_text(extraction_mode='layout', layout_mode_space_vertically=False)}\n"
             return text
         elif file_type == 'odt':
             doc = odfopen.load(file_path)


### PR DESCRIPTION
Hi,

this pull request fixes Alpaca starting to count pages of imported documents from zero, which is rather counter-intuitive for humans that ask stuff like "What's on page 1?". It simply adds 1 to the page index.

How it looks when this fix is applied:
![image](https://github.com/user-attachments/assets/538be7f8-a504-44d3-9d46-dda8ad5de906)

Addresses issue #543.

Greets