### PR TITLE
Update contribution link for Flathub appearance

### DIFF
--- a/data/com.jeffser.Alpaca.metainfo.xml.in
+++ b/data/com.jeffser.Alpaca.metainfo.xml.in
@@ -87,7 +87,7 @@
   <url type="homepage">https://jeffser.com/alpaca/</url>
   <url type="donation">https://github.com/sponsors/Jeffser</url>
   <url type="translate">https://github.com/Jeffser/Alpaca/discussions/153</url>
-  <url type="contribute">https://github.com/Jeffser/Alpaca/discussions/154</url>
+  <url type="contribute">https://github.com/Jeffser/Alpaca/blob/main/CONTRIBUTING.md</url>
   <url type="vcs-browser">https://github.com/Jeffser/Alpaca</url>
   <releases>
     <release version="4.0.1" date="2025-02-03">


### PR DESCRIPTION
Hello there yet again,

this is another minor fix addressing a dead link on the application's Flathub page:

![image](https://github.com/user-attachments/assets/5ab3d10e-9c2b-4489-87e9-0fd4abd96e1b)

The "Contributing" URL points to this outdated page:

![image](https://github.com/user-attachments/assets/8bf416ca-aa37-4006-a19e-7b45d813a6ab)

This pull request changes said link to point directly to the new `CONTRIBUTING.md` file at the project's root directory, avoiding sending users to an outdated page and saving them an extra click.

Best wishes
