### PR TITLE
Minor refactoring and encapsulation of constants, add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,179 @@
+# Alpaca/Adwaita-App-specific files to be excluded
+
+.flatpak-builder/
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,0 +1,58 @@
+# constants.py
+"""
+Holds a few constant values that can be re-used all over the application.
+"""
+import os
+
+
+# The app identifier
+APP_ID = "com.jeffser.Alpaca"
+
+
+# Big thanks to everyone contributing translations.
+# These translators will be shown inside of the app under
+# "About Alpaca" > "Contributors".
+TRANSLATORS: "list[str]" = [
+    "Alex K (Russian) https://github.com/alexkdeveloper",
+    "Jeffry Samuel (Spanish) https://github.com/jeffser",
+    "Louis Chauvet-Villaret (French) https://github.com/loulou64490",
+    "Théo FORTIN (French) https://github.com/topiga",
+    "Daimar Stein (Brazilian Portuguese) https://github.com/not-a-dev-stein",
+    "Bruno Antunes (Brazilian Portuguese) https://github.com/antun3s",
+    "CounterFlow64 (Norwegian) https://github.com/CounterFlow64",
+    "Aritra Saha (Bengali) https://github.com/olumolu",
+    "Yuehao Sui (Simplified Chinese) https://github.com/8ar10der",
+    "Aleksana (Simplified Chinese) https://github.com/Aleksanaa",
+    "Aritra Saha (Hindi) https://github.com/olumolu",
+    "YusaBecerikli (Turkish) https://github.com/YusaBecerikli",
+    "Simon (Ukrainian) https://github.com/OriginalSimon",
+    "Marcel Margenberg (German) https://github.com/MehrzweckMandala",
+    "Magnus Schlinsog (German) https://github.com/mags0ft",
+    "Edoardo Brogiolo (Italian) https://github.com/edo0",
+    "Shidore (Japanese) https://github.com/sh1d0re",
+    "Henk Leerssen (Dutch) https://github.com/Henkster72",
+    "Nofal Briansah (Indonesian) https://github.com/nofalbriansah",
+    "Harimanish (Tamil) https://github.com/harimanish",
+]
+
+
+# Used for identifying the platform running Alpaca.
+class Platforms:
+    windows: str = "win32"
+    mac_os: str = "darwin"
+    linux: str = "linux"
+
+    # Platforms Alpaca is ported to, but does not fully support yet.
+    ported: "tuple[str]" = (mac_os, windows)
+
+
+# Folders Alpaca uses for its operation.
+class AlpacaFolders:
+    tmp_dir = os.path.join("/", "tmp", "alpaca")
+    website_temp: str = os.path.join(tmp_dir, "websites")
+
+    # extensions for paths are only meant to be used with a root path to be
+    # concatenated with simultaneously
+    youtube_temp_ext: str = "tmp/youtube"
+    ollama_temp_ext: str = "tmp/ollama"
+    images_temp_ext: str = "tmp/images"

--- a/src/constants.py
+++ b/src/constants.py
@@ -33,6 +33,7 @@ TRANSLATORS: "list[str]" = [
     "Henk Leerssen (Dutch) https://github.com/Henkster72",
     "Nofal Briansah (Indonesian) https://github.com/nofalbriansah",
     "Harimanish (Tamil) https://github.com/harimanish",
+    "Ekaterine Papava (Georgian) https://github.com/EkaterinePapava",
 ]
 
 

--- a/src/generic_actions.py
+++ b/src/generic_actions.py
@@ -6,11 +6,14 @@ Working on organizing the code
 import gi
 from gi.repository import GLib
 import os, requests, re
+
 from youtube_transcript_api import YouTubeTranscriptApi
 from youtube_transcript_api.formatters import TextFormatter
 from html2text import html2text
-from .internal import cache_dir
+
+from .constants import AlpacaFolders
 from .custom_widgets import model_manager_widget
+from .internal import cache_dir
 
 window = None
 
@@ -34,9 +37,9 @@ def attach_youtube(video_title:str, video_author:str, watch_url:str, video_url:s
     result_text += TextFormatter().format_transcript(transcript)
     #result_text += '\n'.join([t['text'] for t in transcript])
 
-    if not os.path.exists(os.path.join(cache_dir, 'tmp/youtube')):
-        os.makedirs(os.path.join(cache_dir, 'tmp/youtube'))
-    file_path = os.path.join(os.path.join(cache_dir, 'tmp/youtube'), '{} ({})'.format(video_title.replace('/', ' '), caption_name))
+    if not os.path.exists(os.path.join(cache_dir, AlpacaFolders.youtube_temp_ext)):
+        os.makedirs(os.path.join(cache_dir, AlpacaFolders.youtube_temp_ext))
+    file_path = os.path.join(os.path.join(cache_dir, AlpacaFolders.youtube_temp_ext), '{} ({})'.format(video_title.replace('/', ' '), caption_name))
     with open(file_path, 'w+', encoding="utf-8") as f:
         f.write(result_text)
 
@@ -55,8 +58,8 @@ def attach_website(url:str):
         GLib.idle_add(buffer.delete, buffer.get_start_iter(), buffer.get_end_iter())
         GLib.idle_add(buffer.insert, buffer.get_start_iter(), textview_text, len(textview_text))
 
-        if not os.path.exists('/tmp/alpaca/websites/'):
-            os.makedirs('/tmp/alpaca/websites/')
+        if not os.path.exists(f'{AlpacaFolders.website_temp}/'):
+            os.makedirs(f'{AlpacaFolders.website_temp}/')
 
         website_title = 'website'
         match = re.search(r'^# (.+)', md, re.MULTILINE)
@@ -66,9 +69,9 @@ def attach_website(url:str):
             match = re.search(r'https?://(?:www\.)?([^/]+)', url)
             if match:
                 website_title = match.group(1)
-        website_title = window.generate_numbered_name(website_title, os.listdir('/tmp/alpaca/websites'))
+        website_title = window.generate_numbered_name(website_title, os.listdir(f'{AlpacaFolders.website_temp}'))
 
-        file_path = os.path.join('/tmp/alpaca/websites/', website_title)
+        file_path = os.path.join(f'{AlpacaFolders.website_temp}/', website_title)
         with open(file_path, 'w+', encoding="utf-8") as f:
             f.write('{}\n\n{}'.format(url, md))
         window.attach_file(file_path, 'website')

--- a/src/instance_manager.py
+++ b/src/instance_manager.py
@@ -8,6 +8,8 @@ from gi.repository import Adw, Gtk, GLib
 
 import openai, requests, json, logging, os, shutil, subprocess, threading, re
 from pydantic import BaseModel
+
+from .constants import AlpacaFolders
 from .internal import source_dir, data_dir, cache_dir
 from .custom_widgets import dialog_widget
 from . import available_models_descriptions
@@ -303,11 +305,11 @@ class ollama_managed(base_ollama):
     def start(self):
         self.stop()
         if shutil.which('ollama'):
-            if not os.path.isdir(os.path.join(cache_dir, 'tmp/ollama')):
-                os.mkdir(os.path.join(cache_dir, 'tmp/ollama'))
+            if not os.path.isdir(os.path.join(cache_dir, AlpacaFolders.ollama_temp_ext)):
+                os.mkdir(os.path.join(cache_dir, AlpacaFolders.ollama_temp_ext))
             params = self.overrides.copy()
             params["OLLAMA_HOST"] = self.instance_url
-            params["TMPDIR"] = os.path.join(cache_dir, 'tmp/ollama')
+            params["TMPDIR"] = os.path.join(cache_dir, AlpacaFolders.ollama_temp_ext)
             params["OLLAMA_MODELS"] = self.model_directory
             self.process = subprocess.Popen(["ollama", "serve"], env={**os.environ, **params}, stderr=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
             threading.Thread(target=self.log_output, args=(self.process.stdout,)).start()

--- a/src/internal.py
+++ b/src/internal.py
@@ -2,10 +2,13 @@
 """
 Handles paths, they can be different if the app is running as a Flatpak
 """
+
 import os
 
-APP_ID = "com.jeffser.Alpaca"
+from .constants import APP_ID
 
+
+# The identifier when inside the Flatpak runtime
 IN_FLATPAK = bool(os.getenv("FLATPAK_ID"))
 
 def get_xdg_home(env, default):

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 from gi.repository import Gtk, Gio, Adw, GLib
 
+from .constants import TRANSLATORS, Platforms
 from .window import AlpacaWindow
 from .internal import cache_dir, data_dir
 
@@ -39,29 +40,6 @@ import sqlite3
 from pydbus import SessionBus
 
 logger = logging.getLogger(__name__)
-
-translators = [
-    'Alex K (Russian) https://github.com/alexkdeveloper',
-    'Jeffry Samuel (Spanish) https://github.com/jeffser',
-    'Louis Chauvet-Villaret (French) https://github.com/loulou64490',
-    'Théo FORTIN (French) https://github.com/topiga',
-    'Daimar Stein (Brazilian Portuguese) https://github.com/not-a-dev-stein',
-    'Bruno Antunes (Brazilian Portuguese) https://github.com/antun3s',
-    'CounterFlow64 (Norwegian) https://github.com/CounterFlow64',
-    'Aritra Saha (Bengali) https://github.com/olumolu',
-    'Yuehao Sui (Simplified Chinese) https://github.com/8ar10der',
-    'Aleksana (Simplified Chinese) https://github.com/Aleksanaa',
-    'Aritra Saha (Hindi) https://github.com/olumolu',
-    'YusaBecerikli (Turkish) https://github.com/YusaBecerikli',
-    'Simon (Ukrainian) https://github.com/OriginalSimon',
-    'Marcel Margenberg (German) https://github.com/MehrzweckMandala',
-    'Magnus Schlinsog (German) https://github.com/mags0ft',
-    'Edoardo Brogiolo (Italian) https://github.com/edo0',
-    'Shidore (Japanese) https://github.com/sh1d0re',
-    'Henk Leerssen (Dutch) https://github.com/Henkster72',
-    'Nofal Briansah (Indonesian) https://github.com/nofalbriansah',
-    'Harimanish (Tamil) https://github.com/harimanish'
-]
 
 parser = argparse.ArgumentParser(description="Alpaca")
 
@@ -146,7 +124,7 @@ class AlpacaApplication(Adw.Application):
         if not win:
             win = AlpacaWindow(application=self)
         win.present()
-        if sys.platform == 'darwin': # MacOS
+        if sys.platform == Platforms.mac_os: # MacOS
             settings = Gtk.Settings.get_default()
             if settings:
                 settings.set_property('gtk-xft-antialias', 1)
@@ -154,11 +132,11 @@ class AlpacaApplication(Adw.Application):
                 settings.set_property('gtk-font-name', 'Apple SD Gothic Neo')
                 settings.set_property('gtk-xft-dpi', 110592)
             win.add_css_class('macos')
-        elif sys.platform == 'win32': # Windows
+        elif sys.platform == Platforms.windows: # Windows
             settings = Gtk.Settings.get_default()
             if settings:
                 settings.set_property('gtk-font-name', 'Segoe UI')
-        if sys.platform in ('darwin', 'win32') # MacOS and Windows
+        if sys.platform in Platforms.ported: # MacOS and Windows
             win.powersaver_warning_switch.set_visible(False)
             win.background_switch.set_visible(False)
 
@@ -171,7 +149,7 @@ class AlpacaApplication(Adw.Application):
             support_url="https://github.com/Jeffser/Alpaca/discussions/155",
             developers=['Jeffser https://jeffser.com'],
             designers=['Jeffser https://jeffser.com', 'Tobias Bernard (App Icon) https://tobiasbernard.com/'],
-            translator_credits='\n'.join(translators),
+            translator_credits='\n'.join(TRANSLATORS),
             copyright='© 2025 Alpaca Jeffry Samuel Eduarte Rojas\n© 2025 Ollama Meta Platforms, Inc.\n© 2025 ChatGPT OpenAI, Inc.\n© 2025 Gemini Google Alphabet, Inc.\n© 2025 Together.ai\n© 2025 Venice AI',
             issue_url='https://github.com/Jeffser/Alpaca/issues',
             license_type=3,
@@ -224,10 +202,13 @@ def main(version):
         sqlite_con.commit()
         sqlite_con.close()
 
-    if os.path.isdir(os.path.join(cache_dir, 'tmp')):
+    cache_dir_path: str = os.path.join(cache_dir, 'tmp')
+    if os.path.isdir(cache_dir_path):
+        # TODO: Change this, this is error-prone.
+        # And very dangerous, if bwrap doesn't do a good job.
         os.system('rm -rf ' + os.path.join(cache_dir, "tmp/*"))
     else:
-        os.mkdir(os.path.join(cache_dir, 'tmp'))
+        os.mkdir(cache_dir_path)
 
     app = AlpacaApplication(version)
     logger.info(f"Alpaca version: {app.version}")

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,6 +39,7 @@ alpaca_sources = [
   '__init__.py',
   'main.py',
   'window.py',
+  'constants.py',
   'available_models.json',
   'available_models_descriptions.py',
   'internal.py',


### PR DESCRIPTION
Hello and good day,

I refactored a small amount of repeating code and constants and encapsulated these values in their new, own `constants.py` file - a file where everything that's related to non-changing values can be placed, so if something changes in the future, there's one central place to consult and edit!

For example, you do now have this handy `Platforms` class that keeps track of the `sys.platform` values of the platforms that aren't yet fully supported. Once every single feature works on macOS for example, you can simply remove it from the `ported` tuple and it'll be reflected in all of Alpaca.

![image](https://github.com/user-attachments/assets/a5127673-b628-466b-a889-ddb8a5f3f0fc)

Translators are also no longer in the `main.py` file but rather in the `constants.py` file, where they are in a more encapsulated space.

![image](https://github.com/user-attachments/assets/d8d845a7-9413-4f0f-ba0d-c2b058aa0afc)

I also added a `.gitignore` file that allows other editors than GNOME Builder to work with the project more seamlessly.

Last but not least, I re-organized the imports of the files I edited.

Best greets! :)