### PR TITLE
Add all missing German translation strings

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -29,11 +29,11 @@ msgstr "ki;ollama;llm"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:8
 msgid "Chat with AI models"
-msgstr ""
+msgstr "Mit KI-Modellen chatten"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:10
 msgid "A private AI client"
-msgstr ""
+msgstr "Ein privater KI-Client"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:11
 #: data/com.jeffser.Alpaca.metainfo.xml.in:1004
@@ -157,43 +157,43 @@ msgstr "Neu"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:98
 msgid "Tweaked appearance of models in model manager"
-msgstr ""
+msgstr "Aussehen der Modelle im Modell-Manager angepasst"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:99
 msgid "Updated Ollama instance to 0.5.11"
-msgstr ""
+msgstr "Ollama-Instanz auf 0.5.11 aktualisiert"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:100
 msgid "Added new models"
-msgstr ""
+msgstr "Neue Modelle hinzugefügt"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:109
 msgid "New instance manager"
-msgstr ""
+msgstr "Neuer Instanz-Manager"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:110
 msgid "New welcome screen"
-msgstr ""
+msgstr "Neuer Willkommensbildschirm"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:112
 msgid "New Instances"
-msgstr ""
+msgstr "Neue Instanzen"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:114
 msgid "OpenAI ChatGPT"
-msgstr ""
+msgstr "Open AI ChatGPT"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:115
 msgid "Google Gemini"
-msgstr ""
+msgstr "Google Gemini"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:116
 msgid "Together AI"
-msgstr ""
+msgstr "Together AI"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:117
 msgid "Venice"
-msgstr ""
+msgstr "Venice"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:124
 #: data/com.jeffser.Alpaca.metainfo.xml.in:170
@@ -222,11 +222,11 @@ msgstr "Fehlerbehebungen"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:126
 msgid "Exporting chats with 'thoughts' attachment is fixed"
-msgstr ""
+msgstr "Das Exportieren von Chats mit 'Gedanken'-Anhängen ist behoben"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:127
 msgid "Fixed attachment filters"
-msgstr ""
+msgstr "Anhangs-Filter behoben"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:136
 msgid "New model manager"
@@ -1855,11 +1855,11 @@ msgstr "Dies ist die erste öffentliche Version von Alpaca"
 #: src/window.py:152 src/window.py:159 src/window.ui:443 src/window.ui:453
 #: src/window.ui:475
 msgid "Add Instance"
-msgstr ""
+msgstr "Instanz hinzufügen"
 
 #: src/window.py:160
 msgid "Select a type of instance to add"
-msgstr ""
+msgstr "Auswählen, welcher Typ von Instanz hinzugefügt werden soll"
 
 #: src/window.py:348 src/window.py:915
 msgid "Please select a model before chatting"
@@ -2756,6 +2756,8 @@ msgid ""
 "Mistral Small 3 sets a new benchmark in the “small” Large Language Models "
 "category below 70B."
 msgstr ""
+"Mistral Small 3 setzt neue Maße für die Kategorie an “kleinen” "
+"Sprachmodellen unter 70B Parametern."
 
 #: src/available_models_descriptions.py:94
 msgid ""
@@ -3200,6 +3202,9 @@ msgid ""
 "to OpenAI-o1, including six dense models distilled from DeepSeek-R1 based on "
 "Llama and Qwen."
 msgstr ""
+"DeepSeek's erste Generation an Reasoning-Modellen mit vergleichbarer "
+"Leistung zu OpenAI-o1, einschließlich sechs dichter Modelle, die von "
+"DeepSeek-R1 basierend auf Llama und Qwen destilliert wurden."
 
 #: src/available_models_descriptions.py:151
 msgid ""
@@ -3237,6 +3242,8 @@ msgid ""
 "A fully open-source family of reasoning models built using a dataset derived "
 "by distilling DeepSeek-R1."
 msgstr ""
+"Eine vollständig quelloffenene Familie an Reasoning-Modellen, erstellt "
+"mithilfe von Datensätzen, die von DeepSeek-R1 abgeleitet wurden."
 
 #: src/available_models_descriptions.py:155
 msgid ""
@@ -3244,16 +3251,22 @@ msgid ""
 "performance of OpenAI’s o1-preview with just 1.5B parameters on popular math "
 "evaluations."
 msgstr ""
+"Eine feinabgestimmte Version von Deepseek-R1-Distilled-Qwen-1.5B, die die "
+"Leistung von OpenAI's o1-preview mit nur 1.5B Parametern auf häufigen "
+"Mathematikgleichungen übertrifft."
 
 #: src/available_models_descriptions.py:156
 msgid ""
 "A version of the DeepSeek-R1 model that has been post trained to provide "
 "unbiased, accurate, and factual information by Perplexity."
 msgstr ""
+"Eine version vom DeepSeek-R1-Modell, welche durch Perplexity nachtrainiert "
+"wurde, um unvoreingenommene, akkruate und faktenbasierte "
+"Informationswiedergabe zu ermöglichen."
 
 #: src/instance_manager.py:28
 msgid "Instance"
-msgstr ""
+msgstr "Instanz"
 
 #: src/instance_manager.py:58 src/window.ui:162
 #: src/custom_widgets/chat_widget.py:397
@@ -3265,24 +3278,24 @@ msgstr "Neuer Chat"
 #: src/instance_manager.py:588 src/instance_manager.py:729
 #: src/instance_manager.py:757
 msgid "Instance Error"
-msgstr ""
+msgstr "Instanzfehler"
 
 #: src/instance_manager.py:81
 msgid "Message generation failed"
-msgstr ""
+msgstr "Nachrichtengenerierung fehlgeschlagen"
 
 #: src/instance_manager.py:168 src/instance_manager.py:588
 #: src/instance_manager.py:729 src/instance_manager.py:757
 msgid "Could not retrieve added models"
-msgstr ""
+msgstr "Konnte die hinzugefügten Modelle nicht abrufen"
 
 #: src/instance_manager.py:178
 msgid "Could not retrieve available models"
-msgstr ""
+msgstr "Konnte die verfügbaren Modelle nicht abrufen"
 
 #: src/instance_manager.py:246
 msgid "Ollama (Managed)"
-msgstr ""
+msgstr "Ollama (Verwaltet)"
 
 #: src/instance_manager.py:275
 msgid "Alpaca Support"
@@ -3311,7 +3324,7 @@ msgstr "Integrierte Ollama-Instanz läuft nicht"
 
 #: src/instance_manager.py:321
 msgid "Managed Ollama instance failed to start"
-msgstr ""
+msgstr "Mitverwaltete Ollama-Instanz konnte nicht starten"
 
 #: src/instance_manager.py:324
 msgid "Integrated Ollama instance is running"
@@ -3319,11 +3332,11 @@ msgstr "Integrierte Ollama-Instanz läuft"
 
 #: src/instance_manager.py:328
 msgid "Local AI instance managed directly by Alpaca"
-msgstr ""
+msgstr "Lokale KI-Instanz, direkt von Alpaca selbst verwaltet"
 
 #: src/instance_manager.py:331 src/instance_manager.py:332
 msgid "Ollama Log"
-msgstr ""
+msgstr "Ollama-Log"
 
 #: src/instance_manager.py:337 src/instance_manager.py:473
 #: src/instance_manager.py:604 src/window.ui:811
@@ -3332,11 +3345,11 @@ msgstr "Name"
 
 #: src/instance_manager.py:343
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 #: src/instance_manager.py:343
 msgid "Which network port will Ollama use"
-msgstr ""
+msgstr "Welchen Netzwerkport Ollama nutzen wird"
 
 #: src/instance_manager.py:348 src/instance_manager.py:493
 #: src/instance_manager.py:635
@@ -3347,6 +3360,7 @@ msgstr "Temperatur"
 #: src/instance_manager.py:635
 msgid "Increasing the temperature will make the models answer more creatively."
 msgstr ""
+"Die Temperatur zu erhöhen, wird die Modelle kreativer antworten lassen."
 
 #: src/instance_manager.py:351 src/instance_manager.py:496
 #: src/instance_manager.py:639
@@ -3359,6 +3373,8 @@ msgid ""
 "Setting this to a specific number other than 0 will make the model generate "
 "the same text for the same prompt."
 msgstr ""
+"Dies zu einer anderen Zahl als 0 zu setzen, wird die Modelle für dieselben "
+"Eingaben immer dieselben Ausgaben generieren lassen."
 
 #: src/instance_manager.py:356
 msgid "Model Directory"
@@ -3366,7 +3382,7 @@ msgstr "Modellordner"
 
 #: src/instance_manager.py:358
 msgid "Select Directory"
-msgstr ""
+msgstr "Verzeichnis auswählen"
 
 #: src/instance_manager.py:369 src/instance_manager.py:502
 #: src/instance_manager.py:645
@@ -3376,27 +3392,29 @@ msgstr "Standardmodell"
 #: src/instance_manager.py:369 src/instance_manager.py:502
 #: src/instance_manager.py:645
 msgid "Model to select when starting a new chat."
-msgstr ""
+msgstr "Auszuwählendes Modell, wenn ein neuer Chat gestartet wird."
 
 #: src/instance_manager.py:371 src/instance_manager.py:504
 #: src/instance_manager.py:647
 msgid "Title Model"
-msgstr ""
+msgstr "Titel-Modell"
 
 #: src/instance_manager.py:371 src/instance_manager.py:504
 #: src/instance_manager.py:647
 msgid "Model to use when generating a chat title."
-msgstr ""
+msgstr "Zu nutzendes Modell, um die Chat-Titel zu generieren."
 
 #: src/instance_manager.py:387
 msgid "Overrides"
-msgstr ""
+msgstr "Überschreibungen"
 
 #: src/instance_manager.py:387
 msgid ""
 "These entries are optional, they are used to troubleshoot GPU related "
 "problems with Ollama."
 msgstr ""
+"Diese Einträge sind optional, sie werden zur Fehlerbehebung von "
+"GPU-bezogenen Problemen mit Ollama genutzt."
 
 #: src/instance_manager.py:414 src/instance_manager.py:415
 #: src/instance_manager.py:531 src/instance_manager.py:532
@@ -3407,27 +3425,27 @@ msgstr "Speichern"
 
 #: src/instance_manager.py:470
 msgid "Local or remote AI instance not managed by Alpaca"
-msgstr ""
+msgstr "Lokale- oder Remoteinstanz, die nicht durch Alpaca verwaltet wird"
 
 #: src/instance_manager.py:476 src/instance_manager.py:607
 msgid "Instance URL"
-msgstr ""
+msgstr "Instanz-URL"
 
 #: src/instance_manager.py:479
 msgid "API Key (Optional)"
-msgstr ""
+msgstr "API-Schlüssel (optional)"
 
 #: src/instance_manager.py:609 src/instance_manager.py:611
 msgid "API Key (Unchanged)"
-msgstr ""
+msgstr "API-Schlüssel (Unverändert)"
 
 #: src/instance_manager.py:609 src/instance_manager.py:611
 msgid "API Key"
-msgstr ""
+msgstr "API-Schlüssel"
 
 #: src/instance_manager.py:617
 msgid "Max Tokens"
-msgstr ""
+msgstr "Maximale Tokens"
 
 #: src/instance_manager.py:618
 msgid ""
@@ -3435,30 +3453,33 @@ msgid ""
 "a response. More tokens allow longer replies but may take more time and cost "
 "more."
 msgstr ""
+"Definiert die maximale Anzahl an Tokens (Wörter und Leerzeichen), die die "
+"KI in einer Antwort generieren kann. Mehr Tokens ermöglichen längere "
+"Antworten, können aber auch mehr Zeit oder Kosten in Anspruch nehmen."
 
 #: src/instance_manager.py:768
 msgid "OpenAI Compatible Instance"
-msgstr ""
+msgstr "OpenAI-kompatible Instanz"
 
 #: src/instance_manager.py:790
 msgid "Remove Instance?"
-msgstr ""
+msgstr "Instanz entfernen?"
 
 #: src/instance_manager.py:790
 msgid "Are you sure you want to remove this instance?"
-msgstr ""
+msgstr "Sicher, dass diese Instanz entfernt werden soll?"
 
 #: src/instance_manager.py:805
 msgid "Edit Instance"
-msgstr ""
+msgstr "Instanz bearbeiten"
 
 #: src/window.ui:34
 msgid "Loading"
-msgstr ""
+msgstr "Lädt..."
 
 #: src/window.ui:55
 msgid "Welcome"
-msgstr ""
+msgstr "Willkommen"
 
 #: src/window.ui:67 src/window.ui:68
 msgid "Previous"
@@ -3470,7 +3491,7 @@ msgstr "Willkommen bei Alpaca"
 
 #: src/window.ui:104
 msgid "Powering your potential"
-msgstr ""
+msgstr "Entfache dein Potenzial"
 
 #: src/window.ui:112
 msgid ""
@@ -3480,20 +3501,30 @@ msgid ""
 "\n"
 "Alpaca is distributed under GPL v3.0, this software comes with no warranty."
 msgstr ""
+"Alpaca und dessen Entwickler:innen sind nicht für Schäden jeglicher Art "
+"und Weise an Geräten oder Software, entstehend durch die Ausführung "
+"KI-generierter Software, verantwortlich. Besondere Vorsicht bei der "
+"Ausführung solches Codes ist oberstes Gebot und obliegt Alpacas "
+"Nutzer:innen."
+"\n"
+"Alpaca wird unter der GPL v3.0 distributiert. Diese Software kommt ohne "
+"jegliche Garantie."
 
 #: src/window.ui:121
 msgid "Effortless Code Execution"
-msgstr ""
+msgstr "Mühelose Codeausführung"
 
 #: src/window.ui:122
 msgid ""
 "Alpaca can run Python, C++, and even HTML (with a live server) right from "
 "your conversations. Give it a try!"
 msgstr ""
+"Alpaca kann Python, C++ und sogar HTML (mit einem Live-Server) direkt von "
+"ihren Konversationen aus ausführen. Probieren Sie es aus!"
 
 #: src/window.ui:128
 msgid "Your AI, Your Choice"
-msgstr ""
+msgstr "Ihre KI, Ihre Wahl."
 
 #: src/window.ui:129
 msgid ""
@@ -3501,16 +3532,23 @@ msgid ""
 "Customize your experience further by connecting to Google Gemini, OpenAI "
 "ChatGPT, Together.AI, and more."
 msgstr ""
+"Alpaca kommt standardmäßig mit Ollama gebündelt, sodass Sie direkt Zugriff "
+"auf KI haben können. Passen Sie zusätzlich Ihre Nutzungserfahrung weiter "
+"an, indem Sie eine Verbindung mit Google Gemini, OpenAI ChatGPT, "
+"Together.AI und vielen weiteren Diensten herstellen!"
 
 #: src/window.ui:135
 msgid "Private by Design"
-msgstr ""
+msgstr "Privat durch Design"
 
 #: src/window.ui:136
 msgid ""
 "With Alpaca, your conversations are saved locally on your device, so you can "
 "be confident that your data is always secure and private."
 msgstr ""
+"Mit Alpaca werden ihre Konversationen immer lokal auf ihrem Gerät "
+"gespeichert, sodass Sie sich sicher sein können, dass ihre Daten immer "
+"sicher und privat bleiben."
 
 #: src/window.ui:173
 msgid "Menu"
@@ -3561,25 +3599,29 @@ msgstr "Nachricht anhalten"
 
 #: src/window.ui:424
 msgid "Instance Manager"
-msgstr ""
+msgstr "Instanz-Manager"
 
 #: src/window.ui:439
 msgid "No Instances Found"
-msgstr ""
+msgstr "Keine Instanzen gefunden"
 
 #: src/window.ui:440
 msgid "It looks a bit empty in here. Try adding an instance get started!"
 msgstr ""
+"Hier sieht es ein wenig leer aus. Versuchen Sie, eine Instanz hinzuzufügen, "
+"um loszulegen!"
 
 #: src/window.ui:469
 msgid "Added Instances"
-msgstr ""
+msgstr "Hinzugefügte Instanzen"
 
 #: src/window.ui:470
 msgid ""
 "Manage your AI instances, chats and messages are shared between instances "
 "when generating responses."
 msgstr ""
+"Verwalten Sie ihre KI-Instanzen - Chats und Nachrichten sind zwischen "
+"diesen geteilt, wenn Antworten generiert werden."
 
 #: src/window.ui:505
 msgid "Model Manager"
@@ -3603,7 +3645,7 @@ msgstr "Modelle suchen"
 
 #: src/window.ui:595
 msgid "Added"
-msgstr ""
+msgstr "Hinzugefügt"
 
 #: src/window.ui:605 src/window.ui:665 src/window.ui:719
 msgid "No Models Found"
@@ -3614,10 +3656,12 @@ msgid ""
 "It looks a bit empty in here. Try downloading some models or change your AI "
 "instance to get started!"
 msgstr ""
+"Hier sieht es ein wenig leer aus! Versuchen Sie, ein paar Modelle "
+"herunterzuladen, oder ändern Sie die ausgewählte Instanz, um loszulegen!"
 
 #: src/window.ui:609 src/window.ui:619 src/window.ui:1129
 msgid "Manage Instances"
-msgstr ""
+msgstr "Instanzen verwalten"
 
 #: src/window.ui:666 src/window.ui:720
 msgid ""
@@ -3629,11 +3673,11 @@ msgstr ""
 
 #: src/window.ui:678
 msgid "Available"
-msgstr ""
+msgstr "Verfügbar"
 
 #: src/window.ui:732
 msgid "Creator"
-msgstr ""
+msgstr "Ersteller"
 
 #: src/window.ui:743
 msgid "Model Creator"
@@ -3721,7 +3765,7 @@ msgstr "Zeige Energiesparmodus-Warnung"
 
 #: src/window.ui:966
 msgid "Zoom"
-msgstr ""
+msgstr "Vergrößerung"
 
 #: src/window.ui:986
 msgid "Quick ask dialog"
@@ -3785,7 +3829,7 @@ msgstr "Chat löschen"
 
 #: src/window.ui:1181
 msgid "Reload Added Models"
-msgstr ""
+msgstr "Neu hinzugefügte Modelle neu laden"
 
 #: src/window.ui:1185
 msgid "Download Model From Name"
@@ -3846,7 +3890,7 @@ msgstr "Modellmanager"
 #: src/gtk/help-overlay.ui:32
 msgctxt "shortcut window"
 msgid "Instance Manager"
-msgstr ""
+msgstr "Instanz-Manager"
 
 #: src/gtk/help-overlay.ui:38
 msgctxt "shortcut window"
@@ -3886,7 +3930,7 @@ msgstr "Chat umbenennen"
 #: src/gtk/help-overlay.ui:79
 msgctxt "shortcut window"
 msgid "Toggle Searchbars"
-msgstr ""
+msgstr "Suchleisten ein-/ausklappen"
 
 #: src/gtk/help-overlay.ui:87
 msgctxt "shortcut window"
@@ -4623,7 +4667,7 @@ msgstr "Nutzt Flatpak-beinhaltete Shell"
 #~ msgstr "Liste der lokalen Modelle aktualisieren"
 
 #~ msgid "Updating list of available models"
-#~ msgstr "Liste der verfügaren Modelle aktualisieren"
+#~ msgstr "Liste der verfügbaren Modelle aktualisieren"
 
 #~ msgid "Loading chats"
 #~ msgstr "Chats laden"


### PR DESCRIPTION
Greetings,

I've added all the missing German translation strings for the newly added features, changelogs and models to `po/de.po` again and ran them through `msgfmt` to make sure there are no syntax errors.

Have a good one!