### PR TITLE
Patch key error when using vision models (temporary hotfix)

### DIFF
--- a/src/custom_widgets/chat_widget.py
+++ b/src/custom_widgets/chat_widget.py
@@ -249,7 +249,7 @@ class chat(Gtk.Stack):
                 if message.attachment_c and len(message.attachment_c.files) > 0:
                     for attachment in message.attachment_c.files:
                         message_data['content'][0]['text'] += '```{} ({})\n{}\n```\n\n'.format(attachment.get_name(), attachment.file_type, attachment.file_content)
-                message_data['content'][0]['text'] += message.text
+                message_data['content'][0 if ("text" in message_data["content"][0]) else 1]['text'] += message.text
                 if include_metadata:
                     message_data['date'] = message.dt.strftime("%Y/%m/%d %H:%M:%S")
                     message_data['model'] = message.model


### PR DESCRIPTION
Hello there yet again,

as mentioned in issue #586, a KeyError is raised when using vision models with the latest version of Alpaca. This patch introduces a quick and temporary fix for this until your college workload decreases.

Kind regards