### PR TITLE
Fix wrong rendering of OpenThinker reasoning output

### DIFF
--- a/src/custom_widgets/message_widget.py
+++ b/src/custom_widgets/message_widget.py
@@ -32,7 +32,7 @@ language_fallback = {
 markup_pattern = re.compile(r'<(b|u|tt|a.*|span.*)>(.*?)<\/(b|u|tt|a|span)>')
 
 patterns = [
-    ('think', re.compile(r'(?:<think>|<\|begin_of_thought\|>)\n+(.*?)\n+(?:<\/think>|<\|end_of_thought\|>)', re.DOTALL)),
+    ('think', re.compile(r'(?:<think>|<\|begin_of_thought\|>)\n+(.*?)\n+(?:<\/think>|<\|end_of_thought\|>)', re.DOTALL | re.IGNORECASE)),
     ('code', re.compile(r'```([a-zA-Z0-9_+\-]*)\n(.*?)\n\s*```', re.DOTALL)),
     ('code', re.compile(r'`(\w*)\n(.*?)\n\s*`', re.DOTALL)),
     ('table', re.compile(r'((?:\| *[^|\r\n]+ *)+\|)(?:\r?\n)((?:\|[ :]?-+[ :]?)+\|)((?:(?:\r?\n)(?:\| *[^|\r\n]+ *)+\|)+)', re.MULTILINE)),
@@ -47,7 +47,7 @@ def remove_trailing_solution_markers(text: str):
     """
     Removes any trailing markers that reasoning models may leave in their final
     solutions. OpenThinker, for example, uses tags such as
-    <|begin_of_solution|> and <|end_of_solution|> that can be removed.
+    `<|begin_of_solution|>` and `<|end_of_solution|>` that can be removed.
 
     See https://github.com/Jeffser/Alpaca/issues/604.
     """
@@ -55,9 +55,14 @@ def remove_trailing_solution_markers(text: str):
     text = text.strip()
 
     for enclosing_tags in SOLUTION_ENCLOSING_TAGS:
-        if text.endswith(enclosing_tags[1]):
+        if text.casefold().endswith(enclosing_tags[1].casefold()):
             text = text[:-len(enclosing_tags[1])].strip()
-            text = text.replace(enclosing_tags[0], "", 1)
+            text = re.sub(
+                re.escape(enclosing_tags[0]),
+                "",
+                text,
+                flags=re.IGNORECASE
+            )
 
             break
 


### PR DESCRIPTION
Good day,

I've seen the issue on OpenThinker models giving a different output from what reasoning models normally do (#604) and wrote a patch for it, which is included in this pull request.

I did not stumble upon any regressions due to this patch, however I noticed that the "Thought" badge would go away after editing a message, adding a Thought to it by manually typing out `<think>` and `</think>` (or OpenThinker's version of that, respectively) and then switching to another chat and back to the chat where the edit was made. This is an incredibly low priority bug, so I wouldn't bother creating an issue for it.

Greetings!