### PR TITLE
Automatically select correct default model every time

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -293,23 +293,53 @@ class AlpacaWindow(Adw.ApplicationWindow):
             lambda option, options=options: selected(options[option]),
             options.keys()
         )
+    
+    def select_default_model(self) -> None:
+        """
+        Selects the default model of the instance to use.
+        """
+
+        # Automatically select instance default model
+        model_to_use = self.get_current_instance().get_default_model()
+        detected_models = [
+            i for i, el in enumerate(
+                list(self.model_dropdown.get_model())
+            ) if el.model.get_name() == model_to_use
+        ]
+
+        # Only if we found the specific model: select it
+        if len(detected_models) > 0:
+            self.model_dropdown.set_selected(detected_models[0])
 
     @Gtk.Template.Callback()
     def instance_changed(self, listbox, row):
+        """
+        This method is called when the selected instance changes.
+        It updates corresponding UI elements, selections and internal variables.
+        """
+
         def change_instance():
             if self.last_selected_instance_row:
                 self.last_selected_instance_row.instance.stop()
+
             self.last_selected_instance_row = row
+
             model_manager_widget.update_local_model_list()
             model_manager_widget.update_available_model_list()
+
             self.available_models_stack_page.set_visible(len(model_manager_widget.available_models) > 0)
             self.model_creator_stack_page.set_visible(len(model_manager_widget.available_models) > 0)
+
             if row:
                 self.sql_instance.insert_or_update_preferences({'selected_instance': row.instance.instance_id})
+
             self.chat_list_box.update_profile_pictures()
             visible_model_manger_switch = len([p for p in self.model_manager_stack.get_pages() if p.get_visible()]) > 1
+
             self.model_manager_bottom_view_switcher.set_visible(visible_model_manger_switch)
             self.model_manager_top_view_switcher.set_visible(visible_model_manger_switch)
+
+            self.select_default_model()
         if listbox.get_sensitive():
             threading.Thread(target=change_instance).start()
 


### PR DESCRIPTION
Hello, hope you're having a lovely day.

I've added a small function to automatically select the correct default model for a given instance, so that the right one is immediately selected upon app startup or after switching instances - not just after creating a new chat.

This will fix #695.

This fix does not address the potential issue of Alpaca no longer being able to remember which model was last selected in what chat, however that occurs both with the patch and without it.

Hope that helps, and Cheers! :smile: 