### PR TITLE
Add reasoning tag to models to allow for better filtering

### DIFF
--- a/src/available_models.json
+++ b/src/available_models.json
@@ -35,7 +35,8 @@
         "author": "Qwen Team",
         "categories": [
             "tools",
-            "huge"
+            "huge",
+            "reasoning"
         ],
         "languages": [
             "en"
@@ -3277,7 +3278,8 @@
         ],
         "url": "https://ollama.com/library/smallthinker",
         "categories": [
-            "small"
+            "small",
+            "reasoning"
         ],
         "author": "Power Infer",
         "languages": [
@@ -3340,7 +3342,8 @@
             "big",
             "huge",
             "code",
-            "math"
+            "math",
+            "reasoning"
         ],
         "author": "DeepSeek Team",
         "languages": [
@@ -3440,7 +3443,8 @@
         "url": "https://ollama.com/library/openthinker",
         "categories": [
             "small",
-            "huge"
+            "huge",
+            "reasoning"
         ],
         "author": "Open Thoughts Team",
         "languages": [
@@ -3457,7 +3461,8 @@
         "url": "https://ollama.com/library/deepscaler",
         "categories": [
             "small",
-            "math"
+            "math",
+            "reasoning"
         ],
         "author": "Agentica Project",
         "languages": [
@@ -3479,7 +3484,8 @@
         "categories": [
             "huge",
             "multilingual",
-            "math"
+            "math",
+            "reasoning"
         ],
         "author": "Perplexity AI",
         "languages": [
@@ -3695,7 +3701,8 @@
             "medium",
             "big",
             "code",
-            "math"
+            "math",
+            "reasoning"
         ],
         "author": "LG AI Research",
         "languages": [
@@ -3772,7 +3779,8 @@
         "categories": [
             "small",
             "medium",
-            "code"
+            "code",
+            "reasoning"
         ],
         "author": "DeepCoder Team",
         "languages": [

--- a/src/custom_widgets/model_manager_widget.py
+++ b/src/custom_widgets/model_manager_widget.py
@@ -692,6 +692,7 @@ class category_pill(Adw.Bin):
         'vision': {'name': _('Vision'), 'css': ['accent'], 'icon': 'eye-open-negative-filled-symbolic'},
         'embedding': {'name': _('Embedding'), 'css': ['error'], 'icon': 'brain-augemnted-symbolic'},
         'tools': {'name': _('Tools'), 'css': ['accent'], 'icon': 'wrench-wide-symbolic'},
+        'reasoning': {'name': _('Reasoning'), 'css': ['accent'], 'icon': 'brain-augemnted-symbolic'},
         'small': {'name': _('Small'), 'css': ['success'], 'icon': 'leaf-symbolic'},
         'medium': {'name': _('Medium'), 'css': ['brown'], 'icon': 'sprout-symbolic'},
         'big': {'name': _('Big'), 'css': ['warning'], 'icon': 'tree-circle-symbolic'},


### PR DESCRIPTION
Hi there,

I've added a tag to filter by models with reasoning capabilities due to request in #734.

Each model with reasoning now holds a tag called "Reasoning" that can also be used to filter by those that support thinking processes.

This pull request will close #734.

Best regards!