### PR TITLE
update for granite 3.3 phi4 and phi4mini reasoning supported added

### DIFF
--- a/src/available_models.json
+++ b/src/available_models.json
@@ -3777,6 +3777,118 @@
         "author": "DeepCoder Team",
         "languages": [
             "en"
+    },
+    "granite3.3": {
+        "tags": [
+            [
+                "2b",
+                "1.5\u202fGB"
+            ],
+            [
+                "8b",
+                "4.9\u202fGB"
+            ]
+        ],
+        "url": "https://ollama.com/library/granite3.3",
+        "categories": [
+            "code",
+            "math",
+            "small"
+        ],
+        "author": "IBM",
+        "languages": [
+            "en",
+            "de",
+            "es",
+            "fr",
+            "ja",
+            "pt",
+            "ar",
+            "cs",
+            "it",
+            "ko",
+            "nl",
+            "zh"
+        ]
+    },
+    "phi4-mini-reasoning": {
+        "tags": [
+            [
+                "3.8b",
+                "3.2\u202fGB"
+            ]
+        ],
+        "url": "https://ollama.com/library/phi4-mini-reasoning",
+        "categories": [
+            "reasoning",
+            "code",
+            "small"
+        ],
+        "author": "Microsoft",
+        "languages": [
+            "en",
+            "ar",
+            "zh",
+            "cs",
+            "da",
+            "nl",
+            "fi",
+            "fr",
+            "de",
+            "he",
+            "hu",
+            "it",
+            "ja",
+            "ko",
+            "no",
+            "pl",
+            "pt",
+            "ru",
+            "es",
+            "sv",
+            "th",
+            "tr",
+            "uk"
+        ]
+    },
+    "phi4-reasoning": {
+        "tags": [
+            [
+                "14b",
+                "11\u202fGB"
+            ]
+        ],
+        "url": "https://ollama.com/library/phi4-reasoning",
+        "categories": [
+            "reasoning",
+            "code",
+            "medium"
+        ],
+        "author": "Microsoft",
+        "languages": [
+            "en",
+            "ar",
+            "zh",
+            "cs",
+            "da",
+            "nl",
+            "fi",
+            "fr",
+            "de",
+            "he",
+            "hu",
+            "it",
+            "ja",
+            "ko",
+            "no",
+            "pl",
+            "pt",
+            "ru",
+            "es",
+            "sv",
+            "th",
+            "tr",
+            "uk"
         ]
     }
 }

--- a/src/available_models.json
+++ b/src/available_models.json
@@ -3857,6 +3857,11 @@
                 "14b",
                 "11\u202fGB"
             ]
+            [
+                "14b-plus-q4_K_M",
+                "11\u202fGB"
+            ]
+            
         ],
         "url": "https://ollama.com/library/phi4-reasoning",
         "categories": [

--- a/src/available_models.json
+++ b/src/available_models.json
@@ -3777,6 +3777,7 @@
         "author": "DeepCoder Team",
         "languages": [
             "en"
+        ]
     },
     "granite3.3": {
         "tags": [

--- a/src/available_models_descriptions.py
+++ b/src/available_models_descriptions.py
@@ -164,4 +164,7 @@ descriptions = {
    'mistral-small3.1': _("Building upon Mistral Small 3, Mistral Small 3.1 (2503) adds state-of-the-art vision understanding and enhances long context capabilities up to 128k tokens without compromising text performance."),
    'cogito': _("Cogito v1 Preview is a family of hybrid reasoning models by Deep Cogito that outperform the best available open models of the same size, including counterparts from LLaMA, DeepSeek, and Qwen across most standard benchmarks."),
    'deepcoder': _("DeepCoder is a fully open-Source 14B coder model at O3-mini level, with a 1.5B version also available."),
+   'granite3.3': _("IBM Granite 2B and 8B models are 128K context length language models that have been fine-tuned for improved reasoning and instruction-following capabilities."),
+   'phi4-mini-reasoning': _("Phi 4 mini reasoning is a lightweight open model that balances efficiency with advanced reasoning ability."),
+   'phi4-reasoning': _("Phi 4 reasoning and reasoning plus are 14-billion parameter open-weight reasoning models that rival much larger models on complex reasoning tasks."),
 }


### PR DESCRIPTION
This patch adds the support for following
granite 3.3 ibm
phi4 mini microsoft
phi4 microsoft

thanks \