### PR TITLE
Make Alpaca remember the Window size on supported systems

### DIFF
--- a/data/com.jeffser.Alpaca.gschema.xml
+++ b/data/com.jeffser.Alpaca.gschema.xml
@@ -2,4 +2,18 @@
 <schemalist gettext-domain="alpaca">
 	<schema id="com.jeffser.Alpaca" path="/com/jeffser/Alpaca/">
 	</schema>
+	<schema id="com.jeffser.Alpaca.State" path="/com/jeffser/Alpaca/State/">
+		<key name="width" type="i">
+			<default>1300</default>
+		</key>
+		<key name="height" type="i">
+			<default>800</default>
+		</key>
+		<key name="is-maximized" type="b">
+			<default>false</default>
+		</key>
+		<key name="is-fullscreen" type="b">
+			<default>false</default>
+		</key>
+	</schema>
 </schemalist>

--- a/src/window.py
+++ b/src/window.py
@@ -1353,6 +1353,25 @@ class AlpacaWindow(Adw.ApplicationWindow):
         if sys.platform not in Platforms.ported:
             self.model_manager_stack.set_enable_transitions(True)
 
+            # Logic to remember the window size upon application shutdown and
+            # startup; will restore the state of the app after closing and
+            # opening it again, especially useful for large, HiDPI displays.
+            self.settings = Gio.Settings(schema_id="com.jeffser.Alpaca.State")
+
+            # Please also see the GNOME developer documentation:
+            # https://developer.gnome.org/documentation/tutorials/save-state.html
+            for el in [
+                ("width", "default-width"),
+                ("height", "default-height"),
+                ("is-maximized", "maximized")
+            ]:
+                self.settings.bind(
+                    el[0],
+                    self,
+                    el[1],
+                    Gio.SettingsBindFlags.DEFAULT
+                )
+
         self.chat_list_box = chat_widget.chat_list()
         self.chat_list_container.set_child(self.chat_list_box)
 


### PR DESCRIPTION
Good morning, noon, evening or night!

This pull request will make Alpaca remember the size (and, if applicable, whether the window was maximized the last time Alpaca has been used) by using the Gio.Settings API and following the official GNOME developer tutorial in the docs.

This pull request resolves #732.

Have a good day!