### PR TITLE
Handle dismission of file picker gracefully

### DIFF
--- a/src/custom_widgets/chat_widget.py
+++ b/src/custom_widgets/chat_widget.py
@@ -465,7 +465,12 @@ class chat_list(Gtk.ListBox):
         window.sql_instance.duplicate_chat(old_chat_window, new_chat)
 
     def on_chat_imported(self, file_dialog, result):
-        file = file_dialog.open_finish(result)
+        try:
+            file = file_dialog.open_finish(result)
+        except gi.repository.GLib.GError:
+            # The user (probably) dismissed the dialog
+            return
+
         if file:
             if os.path.isfile(os.path.join(cache_dir, 'import.db')):
                 os.remove(os.path.join(cache_dir, 'import.db'))

--- a/src/custom_widgets/model_manager_widget.py
+++ b/src/custom_widgets/model_manager_widget.py
@@ -638,7 +638,7 @@ class local_model(Gtk.Box):
                 _('Change'): {'callback': lambda: dialog_widget.simple_file([window.file_filter_image], set_profile_picture), 'appearance': 'suggested', 'default': True},
             }
 
-            dialog_widget.Options(_("Model Profile Picture"), _("What do you want to do with the model's profile picture?"), list(options.keys())[0], options)
+            dialog_widget.Options(_("Model Profile Picture"), _("What do you want to do with the model's profile picture?"), list(options.keys())[0], options, self)
         else:
             dialog_widget.simple_file([window.file_filter_image], set_profile_picture)
 


### PR DESCRIPTION
Hi,

this pull request now makes Alpaca catch the exception thrown by Gtk.FileDialog when cancelling the action, as it's never a good thing to have exceptions raised in production when something intended happens.

The exception will just silently error out; this is fine, as there is no reason to log it because it is perfectly expected behavior. This could've wreaked havoc if any important control flow would've followed after the dialog selection.

**Also, this pull request fixes a bug that would prevent the user from opening the model profile picture options dialog. I just passed `self` as parent to the Options object, but am unsure about whether this is correct. Please correct it if I'm wrong :smile:**

Have a good day