### PR TITLE
Add stub for Llama API instance type

### DIFF
--- a/src/instance_manager.py
+++ b/src/instance_manager.py
@@ -858,6 +858,21 @@ class klusterai(base_openai):
     instance_url = 'https://api.kluster.ai/v1/'
     description = _('Kluster AI cloud inference API')
 
+
+class LlamaAPI(base_openai):
+    """
+    Instance type for Meta AI's Llama API, using their backwards-compatible
+    OpenAI API endpoint.
+
+    https://llama.developer.meta.com/docs/sdks, see "Other supported libraries"
+    """
+
+    instance_type = 'llama-api'
+    instance_type_display = 'Llama API'
+    instance_url = 'https://api.llama.com/compat/v1/'
+    description = _('Meta AI Llama API')
+
+
 class generic_openai(base_openai):
     instance_type = 'openai:generic'
     instance_type_display = _('OpenAI Compatible Instance')
@@ -933,6 +948,25 @@ def update_instance_list():
         window.instance_listbox.set_selection_mode(1)
         window.instance_listbox.select_row(row)
 
-ready_instances = [ollama_managed, ollama, chatgpt, gemini, together, venice, deepseek, openrouter, anthropic, groq, fireworks, lambda_labs, cerebras, klusterai, generic_openai]
+ready_instances = [
+    ollama_managed,
+    ollama,
+    chatgpt,
+    gemini,
+    together,
+    venice,
+    deepseek,
+    openrouter,
+    anthropic,
+    groq,
+    fireworks,
+    lambda_labs,
+    cerebras,
+    klusterai,
+    generic_openai
+]
 
-
+# TODO:
+# The LlamaAPI instance type is likely ready to use, but needs testing.
+# They currently keep it behind a waitlist. Once testing is done, it can be
+# added to ready_instances.


### PR DESCRIPTION
Hello there,

as @olumolu pointed out in #755, Meta is working on an exciting new Llama API, which, luckily, is OpenAI API compatible. We do not need to add any new dependencies.

This pull request makes everything ready for deployment. Unfortunately, the API is still kept behind a waitlist as of right now, so I haven't been able to conduct testing. As soon as possible, we're going to be able to see whether it works and add `LlamaAPI` to `ready_instances`.

Cheers