### PR TITLE
Add missing reasoning tags to new models

### DIFF
--- a/src/available_models.json
+++ b/src/available_models.json
@@ -3831,7 +3831,8 @@
             "huge",
             "code",
             "math",
-            "multilingual"
+            "multilingual",
+            "reasoning"
         ],
         "author": "Alibaba",
         "languages": [
@@ -3944,7 +3945,8 @@
         "categories": [
             "big",
             "math",
-            "code"
+            "code",
+            "reasoning"
         ],
         "author": "Microsoft",
         "languages": [
@@ -3961,7 +3963,8 @@
         "url": "https://ollama.com/library/phi4-mini-reasoning",
         "categories": [
             "small",
-            "math"
+            "math",
+            "reasoning"
         ],
         "author": "Microsoft",
         "languages": [


### PR DESCRIPTION
Hi,

this pull request updates `available_models.json` to include the new "reasoning" tag for other newly added models that haven't received the tag yet.

Greets