### PR TITLE
Remove duplicated "vision" tags

### DIFF
--- a/src/available_models.json
+++ b/src/available_models.json
@@ -56,7 +56,6 @@
         ],
         "author": "Meta",
         "categories": [
-            "vision",
             "medium",
             "huge",
             "vision"
@@ -463,7 +462,6 @@
         ],
         "author": "Haotian Liu",
         "categories": [
-            "vision",
             "small",
             "medium",
             "huge",
@@ -962,7 +960,6 @@
         ],
         "author": "Xtuner",
         "categories": [
-            "vision",
             "medium",
             "vision"
         ],
@@ -1527,7 +1524,6 @@
         ],
         "author": "Skunkworks AI",
         "categories": [
-            "vision",
             "small",
             "vision"
         ],
@@ -1639,7 +1635,6 @@
         ],
         "author": "Vikhyatk",
         "categories": [
-            "vision",
             "small",
             "vision"
         ],
@@ -2035,7 +2030,6 @@
         ],
         "author": "Xtuner",
         "categories": [
-            "vision",
             "small",
             "vision"
         ],
@@ -2075,7 +2069,6 @@
         ],
         "author": "OpenBMB",
         "categories": [
-            "vision",
             "medium",
             "vision",
             "math",
@@ -3515,7 +3508,6 @@
         ],
         "url": "https://ollama.com/library/gemma3",
         "categories": [
-            "vision",
             "small",
             "medium",
             "big",
@@ -3577,7 +3569,6 @@
         ],
         "url": "https://ollama.com/library/granite3.2-vision",
         "categories": [
-            "vision",
             "tools",
             "small",
             "vision"
@@ -3720,8 +3711,7 @@
         "categories": [
             "vision",
             "tools",
-            "big",
-            "vision"
+            "big"
         ],
         "author": "Mistral AI",
         "languages": [
@@ -3877,7 +3867,6 @@
             "vision",
             "tools",
             "huge",
-            "vision",
             "multilingual",
             "code"
         ],


### PR DESCRIPTION
Hey there,

I know you have your internal tooling to deal with the `available_models.json` file right now, however, I've noticed that the `vision` tag is heavily duplicated all over the. This could be fixed in your script by using a `set`, effectively de-duplicating such tags.

You could consider open-sourcing the internal tooling into a folder like `scripts/` to make these errors fixable for everyone.

Best regards