### PR TITLE
Replace image.get_content() with image["content"]

### DIFF
--- a/src/widgets/chat.py
+++ b/src/widgets/chat.py
@@ -182,7 +182,7 @@ class Notebook(Gtk.Stack):
                     message_data['content'].append({
                         'type': 'image_url',
                         'image_url': {
-                            'url': f'data:image/jpeg;base64,{image.get_content()}'
+                            'url': f'data:image/jpeg;base64,{image["content"]}'
                         }
                     })
                 message_data['content'].append({
@@ -338,7 +338,7 @@ class Chat(Gtk.Stack):
                     message_data['content'].append({
                         'type': 'image_url',
                         'image_url': {
-                            'url': f'data:image/jpeg;base64,{image.get_content()}'
+                            'url': f'data:image/jpeg;base64,{image["content"]}'
                         }
                     })
                 message_data['content'].append({


### PR DESCRIPTION
`image` is a dictionary, not an object. so it doesn't implement .get_content()

This fixes a crash that I've experienced with Vision models, where it would never respond when you attach images.

Without the patch:
![Screenshot-2025-06-10_14:04:38](https://github.com/user-attachments/assets/9b2fdd73-3279-4beb-8559-70d902d368b2)

With the patch (still doesn't know the character, but that's fine):
![Screenshot-2025-06-10_14:10:13](https://github.com/user-attachments/assets/b017fba5-a154-4fe4-a6e2-75e2cef5cdbb)
