### PR TITLE
Fix Ollama startup crash when cache directories don't exist

### DIFF
--- a/src/widgets/instance_manager.py
+++ b/src/widgets/instance_manager.py
@@ -684,8 +684,7 @@ class OllamaManaged(BaseOllama):
     def start(self):
         self.stop()
         if shutil.which('ollama'):
-            if not os.path.isdir(os.path.join(cache_dir, 'tmp', 'ollama')):
-                os.mkdir(os.path.join(cache_dir, 'tmp', 'ollama'))
+            os.makedirs(os.path.join(cache_dir, 'tmp', 'ollama'), exist_ok=True)
             params = self.overrides.copy()
             params["OLLAMA_HOST"] = self.instance_url
             params["TMPDIR"] = os.path.join(cache_dir, 'tmp', 'ollama')
@@ -1081,5 +1080,3 @@ if os.getenv('ALPACA_OLLAMA_ONLY', '0') == '1':
     ready_instances = [OllamaManaged, Ollama]
 else:
     ready_instances = [OllamaManaged, Ollama, ChatGPT, Gemini, Together, Venice, Deepseek, OpenRouter, Anthropic, Groq, Fireworks, LambdaLabs, Cerebras, Klusterai, GenericOpenAI, LlamaAPI]
-
-


### PR DESCRIPTION
Replace `os.mkdir()` with `os.makedirs()` to create missing parent directories and handle cases where they already exist. This previously failed when tmp subdirectory didn't exist on first runs causing:

```
Traceback (most recent call last):
  File "/nix/store/scyd2s43mwz29cmgni5qm8pnyhml3l29-alpaca-6.1.7/share/Alpaca/alpaca/widgets/model_manager.py", line 952, in update_local_model_list
    local_models = window.get_current_instance().get_local_models()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/scyd2s43mwz29cmgni5qm8pnyhml3l29-alpaca-6.1.7/share/Alpaca/alpaca/widgets/instance_manager.py", line 521, in get_local_models
    self.start()
  File "/nix/store/scyd2s43mwz29cmgni5qm8pnyhml3l29-alpaca-6.1.7/share/Alpaca/alpaca/widgets/instance_manager.py", line 676, in start
    os.mkdir(os.path.join(cache_dir, 'tmp', 'ollama'))
FileNotFoundError: [Errno 2] No such file or directory: '/home/e-tho/.cache/com.jeffser.Alpaca/tmp/ollama'
```