### PR TITLE
Add JavaScript fallback for code blocks

### DIFF
--- a/src/widgets/blocks/code.py
+++ b/src/widgets/blocks/code.py
@@ -14,7 +14,8 @@ language_fallback = {
     'batch': 'powershell',
     'c#': 'csharp',
     'vb.net': 'vbnet',
-    'python': 'python3'
+    'python': 'python3',
+    'javascript': 'js',
 }
 
 language_properties = (


### PR DESCRIPTION
Hello there,

this pull request fixes issue https://github.com/Jeffser/Alpaca/issues/858 by simply adding a fallback for the `javascript` language descriptor in markdown syntax.

Greets