### PR TITLE
Minor improvements for title generation

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -202,6 +202,15 @@ SAMPLE_PROMPTS = [
 # The identifier when inside the Flatpak runtime
 IN_FLATPAK = bool(os.getenv("FLATPAK_ID"))
 
+TITLE_GENERATION_PROMPT_OLLAMA = (
+    "You are an assistant that generates short chat titles based on the "
+    "prompt. If you want to, you can add a single emoji.\n\n{}"
+)
+TITLE_GENERATION_PROMPT_OPENAI = (
+    "You are an assistant that generates short chat titles based on the first "
+    "message from a user. If you want to, you can add a single emoji."
+)
+
 def get_xdg_home(env, default):
     if IN_FLATPAK:
         return os.getenv(env)

--- a/src/constants.py
+++ b/src/constants.py
@@ -210,6 +210,7 @@ TITLE_GENERATION_PROMPT_OPENAI = (
     "You are an assistant that generates short chat titles based on the first "
     "message from a user. If you want to, you can add a single emoji."
 )
+MAX_TOKENS_TITLE_GENERATION = 31
 
 def get_xdg_home(env, default):
     if IN_FLATPAK:

--- a/src/widgets/instances/ollama_instances.py
+++ b/src/widgets/instances/ollama_instances.py
@@ -5,7 +5,7 @@ from gi.repository import Adw, Gtk, GLib
 import requests, json, logging, os, shutil, subprocess, threading, re, signal, pwd, getpass
 from .. import dialog, tools
 from ...ollama_models import OLLAMA_MODELS
-from ...constants import data_dir, cache_dir, TITLE_GENERATION_PROMPT
+from ...constants import data_dir, cache_dir, TITLE_GENERATION_PROMPT_OLLAMA, MAX_TOKENS_TITLE_GENERATION
 from ...sql_manager import generate_uuid, Instance as SQL
 
 logger = logging.getLogger(__name__)
@@ -241,7 +241,7 @@ class BaseInstance:
         params = {
             "temperature": 0.2,
             "model": self.get_title_model(),
-            "max_tokens": 50,
+            "max_tokens": MAX_TOKENS_TITLE_GENERATION,
             "stream": False,
             "prompt": TITLE_GENERATION_PROMPT.format(prompt),
             "format": {

--- a/src/widgets/instances/ollama_instances.py
+++ b/src/widgets/instances/ollama_instances.py
@@ -5,7 +5,7 @@ from gi.repository import Adw, Gtk, GLib
 import requests, json, logging, os, shutil, subprocess, threading, re, signal, pwd, getpass
 from .. import dialog, tools
 from ...ollama_models import OLLAMA_MODELS
-from ...constants import data_dir, cache_dir
+from ...constants import data_dir, cache_dir, TITLE_GENERATION_PROMPT
 from ...sql_manager import generate_uuid, Instance as SQL
 
 logger = logging.getLogger(__name__)
@@ -243,7 +243,7 @@ class BaseInstance:
             "model": self.get_title_model(),
             "max_tokens": 50,
             "stream": False,
-            "prompt": "You are an assistant that generates short chat titles based on the prompt. If you want to, you can add a single emoji.\n\n{}".format(prompt),
+            "prompt": TITLE_GENERATION_PROMPT.format(prompt),
             "format": {
                 "type": "object",
                 "properties": {
@@ -270,10 +270,15 @@ class BaseInstance:
                 data=json.dumps(params)
             )
             data = json.loads(response.json().get('response', '{"title": ""}'))
+            generated_title = data.get('title').replace('\n', '').strip()
+
+            if len(generated_title) > 30:
+                generated_title = generated_title[:30].strip() + '...'
+
             if data.get('emoji'):
-                chat.row.rename('{} {}'.format(data.get('emoji').replace('\n', '').strip(), data.get('title').replace('\n', '').strip()))
+                chat.row.rename('{} {}'.format(data.get('emoji').replace('\n', '').strip(), generated_title))
             else:
-                chat.row.rename(data.get('title').replace('\n', '').strip())
+                chat.row.rename(generated_title)
         except Exception as e:
             logger.error(e)
 

--- a/src/widgets/instances/openai_instances.py
+++ b/src/widgets/instances/openai_instances.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from .. import dialog, tools
 from ...sql_manager import generate_uuid, Instance as SQL
+from ...constants import MAX_TOKENS_TITLE_GENERATION, TITLE_GENERATION_PROMPT_OPENAI
 
 logger = logging.getLogger(__name__)
 
@@ -240,7 +241,7 @@ class BaseInstance:
             "temperature": 0.2,
             "model": self.get_title_model(),
             "messages": messages,
-            "max_tokens": 50
+            "max_tokens": MAX_TOKENS_TITLE_GENERATION
         }
         new_chat_title = chat.get_name()
 


### PR DESCRIPTION
Hi Jeffry,

I know the title generation issues have already been addressed by you for a few times, but I've seen issue #773 and wanted to add some final fixes.

A limit of 50 tokens for generation is quite generous, as that would equal a maximum title length of up to 37,5 words of pure text - just for a title! On the other hand, tokens for special characters are used up way faster, so the number of tokens to generate should never be lower than the maximum title length in characters.

This commit adds title length clamping to 30 characters with dots (...) added if text gets too long. The maximum tokens generated are 31 (30 for the title + 1 for the emoji).

It also features some minor re-factoring for better maintainability of the prompts and amount of tokens into `constants.py`.

Hope you're having a lovely day.