### PR TITLE
fix: id.po

### DIFF
--- a/po/id.po
+++ b/po/id.po
@@ -212,17 +212,13 @@ msgstr ""
 msgid "Fixes"
 msgstr "Perbaikan"
 
-#: data/com.jeffser.Alpaca.metainfo.xml.in:97  
-msgid "Fixed inconsistent message generation rendering"  
-msgstr "Memperbaiki render pembuatan pesan yang tidak konsisten"  
-
 #: data/com.jeffser.Alpaca.metainfo.xml.in:101
 msgid "Fixed message rendering problems"
-msgstr "
+msgstr ""
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:110
 msgid "Fixed inconsistent message generation rendering"
-msgstr ""
+msgstr "Memperbaiki render pembuatan pesan yang tidak konsisten"
 
 #: data/com.jeffser.Alpaca.metainfo.xml.in:119
 msgid "Save message edit with ctrl+enter"


### PR DESCRIPTION
`7.5.3` currently fail to compile due to `id.po` having errors.

- Add a missing `"` 
- Remove the following duplicated message definition, which was also pointing to the wrong string:
```po
#: data/com.jeffser.Alpaca.metainfo.xml.in:97  
msgid "Fixed inconsistent message generation rendering"  
msgstr "Memperbaiki render pembuatan pesan yang tidak konsisten"  
```