### PR TITLE
Prevent sending empty messages

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -262,7 +262,7 @@ class AlpacaWindow(Adw.ApplicationWindow):
         buffer = self.global_footer.get_buffer()
 
         raw_message = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), False)
-        if not raw_message:
+        if not raw_message.strip():
             return
 
         current_chat = self.chat_list_box.get_selected_row().chat


### PR DESCRIPTION
Addressing an issue where messages containing only whitespace (like spaces or newlines) were being sent. The raw message is now stripped of leading and trailing whitespace before validation. This ensures that only messages with actual content go through.

Example:
<img width="1245" height="483" alt="image" src="https://github.com/user-attachments/assets/6e2fff90-7c4a-4ce7-b94c-ec5c23ce247e" />
This empty string being sent seem to also break the chat. Since AI response now just keep loading forever.