### PR TITLE
Add Zoom In/Out shortcuts and ensure Consistent Scaling

### DIFF
--- a/src/gtk/help-overlay.ui
+++ b/src/gtk/help-overlay.ui
@@ -53,6 +53,18 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Zoom In</property>
+                <property name="action-name">app.zoom_in</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Zoom Out</property>
+                <property name="action-name">app.zoom_out</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Quit</property>
                 <property name="action-name">app.quit</property>
               </object>

--- a/src/widgets/preferences.py
+++ b/src/widgets/preferences.py
@@ -24,9 +24,12 @@ class PreferencesDialog(Adw.PreferencesDialog):
 
     @Gtk.Template.Callback()
     def zoom_changed(self, spinner):
-        settings = Gtk.Settings.get_default()
-        settings.reset_property('gtk-xft-dpi')
-        settings.set_property('gtk-xft-dpi',  settings.get_property('gtk-xft-dpi') + (int(spinner.get_value()) - 100) * 400)
+        gtk_settings = Gtk.Settings.get_default()
+        gtk_settings.reset_property('gtk-xft-dpi')
+        zoom_value = int(spinner.get_value())
+        baseline_dpi = 96 * 1024
+        dpi = baseline_dpi + (zoom_value - 100) * 400
+        gtk_settings.set_property('gtk-xft-dpi', dpi)
 
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Align zoom logic between Preferences and keyboard shortcuts, ensuring consistent scaling.

- Refactored both the Preferences dialog (`zoom_changed`) and window shortcut zoom logic to use a shared DPI calculation based on a 96*1024 baseline. [GTK Standard](https://docs.gtk.org/gtk4/property.Settings.gtk-xft-dpi.html)
- Zoom is now consistently clamped between 100 and 200 in steps of 10, matching the UI spinbox.
- Removed cumulative DPI calculations to prevent drift and ensure both settings and shortcuts always result in identical UI scaling.
- Both zoom methods now update and apply the same GSettings value for persistence and UI sync.
- This ensures users experience consistent zoom behavior regardless of whether they use shortcuts or the Preferences dialog.

I've cooked this up :) :
<img width="590" height="536" alt="image" src="https://github.com/user-attachments/assets/d9915c1d-6e2a-4835-86a1-88cc0a0bb30c" />

https://github.com/user-attachments/assets/9474edab-adc1-48ae-9fa8-4c4fda0fba40

