### PR TITLE
Fix for the prettify_model_name function crash

### DIFF
--- a/src/sql_manager.py
+++ b/src/sql_manager.py
@@ -103,21 +103,32 @@ def generate_numbered_name(name: str, compare_list: "list[str]") -> str:
                     break
     return name
 
-def prettify_model_name(name:str, separated:bool=False) -> str or tuple:
-    if name:
-        if ':' in name:
-            name = name.split(':')
-            if separated:
-                return name[0].replace('-', ' ').title(), name[1].replace('-', ' ').title()
-            elif name[1].lower() in ('latest', 'custom'):
-                return name[0].replace('-', ' ').title()
-            else:
-                return '{} ({})'.format(name[0].replace('-', ' ').title(), name[1].replace('-', ' ').title())
-        else:
-            if separated:
-                return name.replace('-', ' ').title(), None
-            else:
-                return name.replace('-', ' ').title()
+def prettify_model_name(name, separated: bool = False):
+    if isinstance(name, dict):
+        name = name.get("name", "Unknown")
+    elif not isinstance(name, str):
+        name = str(name)
+
+    if not name:
+        return ("Unknown", None) if separated else "Unknown"
+
+    if ':' in name:
+        parts = name.split(':')
+        model = parts[0].replace('-', ' ').title()
+        tag = parts[1].replace('-', ' ').title()
+
+        if separated:
+            return model, tag
+
+        if tag.lower() in ('latest', 'custom'):
+            return model
+
+        return f"{model} ({tag})"
+
+    else:
+        model = name.replace('-', ' ').title()
+        return (model, None) if separated else model
+
 
 class SQLiteConnection:
     """


### PR DESCRIPTION
Alpaca expected a string model name, but instead got a dict, usually coming from ollama list output.

Crash log:
------------------------------------------------------------- 
return name.replace('-', ' ').title()
AttributeError: 'dict' object has no attribute 'replace'
-------------------------------------------------------------

INFO     [alpaca.logging] Logging initialized
INFO     [numexpr.utils] Note: NumExpr detected 24 cores but "NUMEXPR_MAX_THREADS" not set, so enforcing safe limit of 16.
INFO     [numexpr.utils] NumExpr defaulting to 16 threads.
INFO     [alpaca.main] Alpaca version: 8.4.2
INFO     [alpaca.widgets.instances.ollama_instances] Starting Alpaca's Ollama instance...
INFO     [alpaca.widgets.instances.ollama_instances] Started Alpaca's Ollama instance
INFO     [alpaca.widgets.instances.ollama_instances] client version is 0.12.11
Traceback (most recent call last):
  File "/usr/local/share/Alpaca/alpaca/widgets/instances/__init__.py", line 338, in <lambda>
    edit_button.connect('clicked', lambda button: self.show_edit())
                                                  ~~~~~~~~~~~~~~^^
  File "/usr/local/share/Alpaca/alpaca/widgets/instances/__init__.py", line 342, in show_edit
    InstancePreferencesDialog(self.instance).present(self.get_root())
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/local/share/Alpaca/alpaca/widgets/instances/__init__.py", line 132, in __init__
    self.set_simple_element_value(self.title_model_el)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/share/Alpaca/alpaca/widgets/instances/__init__.py", line 157, in set_simple_element_value
    if model.get_string() == prettify_model_name(value):
                             ~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/usr/local/share/Alpaca/alpaca/sql_manager.py", line 120, in prettify_model_name
    return name.replace('-', ' ').title()
           ^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'replace'
Traceback (most recent call last):
  File "/usr/local/share/Alpaca/alpaca/widgets/instances/__init__.py", line 338, in <lambda>
    edit_button.connect('clicked', lambda button: self.show_edit())
                                                  ~~~~~~~~~~~~~~^^
  File "/usr/local/share/Alpaca/alpaca/widgets/instances/__init__.py", line 342, in show_edit
    InstancePreferencesDialog(self.instance).present(self.get_root())
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/local/share/Alpaca/alpaca/widgets/instances/__init__.py", line 132, in __init__
    self.set_simple_element_value(self.title_model_el)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/share/Alpaca/alpaca/widgets/instances/__init__.py", line 157, in set_simple_element_value
    if model.get_string() == prettify_model_name(value):
                             ~~~~~~~~~~~~~~~~~~~^^^^^^^
  File "/usr/local/share/Alpaca/alpaca/sql_manager.py", line 120, in prettify_model_name
    return name.replace('-', ' ').title()
           ^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'replace'
INFO     [alpaca.widgets.instances.ollama_instances] Stopping Alpaca's Ollama instance
INFO     [alpaca.widgets.instances.ollama_instances] Stopped Alpaca's Ollama instance
**
Gtk:ERROR:../../../gtk/gtkcountingbloomfilterprivate.h:122:gtk_counting_bloom_filter_remove: assertion failed: (self->buckets[bucket] > 0)
Bail out! Gtk:ERROR:../../../gtk/gtkcountingbloomfilterprivate.h:122:gtk_counting_bloom_filter_remove: assertion failed: (self->buckets[bucket] > 0)
Aborted                    (core dumped)