### PR TITLE
add current time to system prompt

### DIFF
--- a/src/widgets/instances/ollama_instances.py
+++ b/src/widgets/instances/ollama_instances.py
@@ -2,7 +2,7 @@
 
 from gi.repository import Adw, Gtk, GLib
 
-import requests, json, logging, os, shutil, subprocess, threading, re, signal, pwd, getpass
+import requests, json, logging, os, shutil, subprocess, threading, re, signal, pwd, getpass, datetime
 from .. import dialog, tools, chat
 from ...ollama_models import OLLAMA_MODELS
 from ...constants import data_dir, cache_dir, TITLE_GENERATION_PROMPT_OLLAMA, MAX_TOKENS_TITLE_GENERATION
@@ -152,6 +152,13 @@ class BaseInstance:
                     'role': 'system',
                     'content': model_info.get('system')
                 })
+
+        time_now = datetime.datetime.now().replace(microsecond=0).astimezone().isoformat()
+
+        messages.insert(0, {
+            'role': 'system',
+            'content': 'Current time is {}'.format(time_now),
+        })
 
         params = {
             "model": model,


### PR DESCRIPTION
When LLM uses web search, it begins to question the authenticity of the timestamps on the web page, wasting tokens and producing unnecessary outputs. Give it ​​a current timestamp in system prompt to avoid this problem. (Even in offline mode, it is helpful to prompt it with the current time to avoid it assuming stale information as latest).