### PR TITLE
add UI constants and replace magic numbers

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -286,6 +286,12 @@ CODE_LANGUAGE_PROPERTIES = (
     }
 )
 
+# UI Constants
+SCROLL_THRESHOLD = 150  # Pixels from bottom to trigger auto-scroll
+ICON_SIZE_SMALL = 40  # Small icon size in pixels
+ICON_SIZE_MEDIUM = 64  # Medium icon size in pixels
+SCROLL_INTERVAL_MS = 30  # Scroll animation interval in milliseconds
+
 # The identifier when inside the Flatpak runtime
 IN_FLATPAK = bool(os.getenv("FLATPAK_ID"))
 

--- a/src/widgets/chat.py
+++ b/src/widgets/chat.py
@@ -6,7 +6,7 @@ Handles the chat widget
 import gi
 from gi.repository import Gtk, Gio, Adw, Gdk, GLib
 import logging, os, datetime, random, json, threading, re, importlib.util
-from ..constants import SAMPLE_PROMPTS, cache_dir
+from ..constants import SAMPLE_PROMPTS, cache_dir, SCROLL_INTERVAL_MS
 from ..sql_manager import generate_uuid, prettify_model_name, generate_numbered_name, Instance as SQL
 from . import dialog, voice, models
 from .message import Message
@@ -56,7 +56,7 @@ class Folder(Adw.NavigationPage):
     def start_scrolling(self, direction):
         if self._scroll_timeout_id:
             GLib.source_remove(self._scroll_timeout_id)
-        self._scroll_timeout_id = GLib.timeout_add(30, self.do_scroll, direction)
+        self._scroll_timeout_id = GLib.timeout_add(SCROLL_INTERVAL_MS, self.do_scroll, direction)
 
     def stop_scrolling(self):
         if self._scroll_timeout_id:

--- a/src/widgets/message.py
+++ b/src/widgets/message.py
@@ -6,6 +6,7 @@ Handles the message widget
 import gi
 from gi.repository import Gtk, Gio, Adw, GLib, Gdk, GtkSource, Spelling
 import os, datetime, threading, sys, base64, logging, re, tempfile
+from .. import constants
 from ..sql_manager import prettify_model_name, generate_uuid, format_datetime, Instance as SQL
 from . import attachments, blocks, dialog, voice, tools, models, chat, activities
 
@@ -259,8 +260,8 @@ class Message(Gtk.Box):
             image_data = base64.b64decode(pfp_b64)
             texture = Gdk.Texture.new_from_bytes(GLib.Bytes.new(image_data))
             image_element = Gtk.Image.new_from_paintable(texture)
-            image_element.set_size_request(40, 40)
-            image_element.set_pixel_size(40)
+            image_element.set_size_request(constants.ICON_SIZE_SMALL, constants.ICON_SIZE_SMALL)
+            image_element.set_pixel_size(constants.ICON_SIZE_SMALL)
             self.pfp_options_button.set_child(image_element)
             list(self.pfp_options_button)[0].set_overflow(1)
 
@@ -306,7 +307,7 @@ class Message(Gtk.Box):
             chat_element = self.get_ancestor(chat.Chat)
             if chat_element:
                 vadjustment = chat_element.scrolledwindow.get_vadjustment()
-                if vadjustment.get_value() + 150 >= vadjustment.get_upper() - vadjustment.get_page_size():
+                if vadjustment.get_value() + constants.SCROLL_THRESHOLD >= vadjustment.get_upper() - vadjustment.get_page_size():
                     GLib.idle_add(vadjustment.set_value, vadjustment.get_upper() - vadjustment.get_page_size())
         if self.block_container.thinking_block and self.block_container.thinking_block.get_parent():
             attachment = attachments.Attachment(
@@ -327,7 +328,7 @@ class Message(Gtk.Box):
             chat_element = self.get_ancestor(chat.Chat)
             if chat_element:
                 vadjustment = chat_element.scrolledwindow.get_vadjustment()
-                if vadjustment.get_value() + 150 >= vadjustment.get_upper() - vadjustment.get_page_size():
+                if vadjustment.get_value() + constants.SCROLL_THRESHOLD >= vadjustment.get_upper() - vadjustment.get_page_size():
                     GLib.idle_add(vadjustment.set_value, vadjustment.get_upper() - vadjustment.get_page_size())
 
     def finish_generation(self, response_metadata:str=None):


### PR DESCRIPTION
Add UI constants for better code maintainability:
- SCROLL_THRESHOLD (150px) - pixels from bottom to trigger auto-scroll
- ICON_SIZE_SMALL (40px) - small icon size
- ICON_SIZE_MEDIUM (64px) - medium icon size
- SCROLL_INTERVAL_MS (30ms) - scroll animation interval

Replace magic numbers throughout the codebase with named constants in:
- src/widgets/chat.py: scroll interval
- src/widgets/message.py: icon sizes and scroll threshold