### PR TITLE
Added cloudflare ai inference provider support

### DIFF
--- a/src/widgets/instances/__init__.py
+++ b/src/widgets/instances/__init__.py
@@ -92,7 +92,12 @@ class InstancePreferencesDialog(Adw.Dialog):
             unchanged_api_title = _('API Key (Unchanged)')
             self.api_el.set_title(unchanged_api_title if self.instance.properties.get('api') else normal_api_title)
             self.api_el.connect('changed', lambda el: el.set_title(normal_api_title if el.get_text() else unchanged_api_title))
-        self.set_simple_element_value(self.api_el)
+
+            if self.instance.instance_type == 'cloudflare':
+                self.api_el.set_placeholder_text("account_id:api_key")
+            else:
+                self.api_el.set_placeholder_text("") 
+            self.set_simple_element_value(self.api_el)
 
         # TWEAK GROUP
         self.set_simple_element_value(self.think_el)

--- a/src/widgets/instances/__init__.py
+++ b/src/widgets/instances/__init__.py
@@ -69,7 +69,7 @@ class InstancePreferencesDialog(Adw.Dialog):
         self.set_simple_element_value(self.name_el)
 
         self.set_simple_element_value(self.url_el)
-        if self.instance.instance_type in ('ollama', 'ollama:managed', 'openai:generic'):
+        if self.instance.instance_type in ('ollama', 'ollama:managed', 'openai:generic', 'cloudflare'):
             if self.instance.instance_type == 'ollama:managed':
                 try:
                     port = int(self.instance.properties.get('url').split(':')[-1])

--- a/src/widgets/instances/__init__.py
+++ b/src/widgets/instances/__init__.py
@@ -69,7 +69,7 @@ class InstancePreferencesDialog(Adw.Dialog):
         self.set_simple_element_value(self.name_el)
 
         self.set_simple_element_value(self.url_el)
-        if self.instance.instance_type in ('ollama', 'ollama:managed', 'openai:generic', 'cloudflare'):
+        if self.instance.instance_type in ('ollama', 'ollama:managed', 'openai:generic'):
             if self.instance.instance_type == 'ollama:managed':
                 try:
                     port = int(self.instance.properties.get('url').split(':')[-1])

--- a/src/widgets/instances/openai_instances.py
+++ b/src/widgets/instances/openai_instances.py
@@ -713,7 +713,7 @@ class Cloudflare(BaseInstance):
             )
             logger.error(e)
             if self.row:
-                self.row.get_parent().unselect_all()
+                GLib.idle_add(self.row.get_parent().unselect_all)
             return {}
 
 class GenericOpenAI(BaseInstance):

--- a/src/widgets/instances/openai_instances.py
+++ b/src/widgets/instances/openai_instances.py
@@ -652,6 +652,70 @@ class SarvamAI(BaseInstance):
                 default_headers={"api-subscription-key": self.properties.get('api')}
             )
 
+class Cloudflare(BaseInstance):
+    instance_type = 'cloudflare'
+    instance_type_display = 'Cloudflare Workers AI'
+    instance_url = ''
+    description = _('Enter credentials in the API Key field as: Account_ID:API_Key')
+
+    def start(self):
+        if not self.client:
+            # Get the text from the API Key field
+            api_prop = self.properties.get('api', '')
+            account_id = "ACCOUNT_ID"
+            api_key = api_prop
+            
+            # Split the string at the first colon
+            if ':' in api_prop:
+                account_id, api_key = api_prop.split(':', 1)
+            
+            # Connect using the extracted account_id and api_key
+            self.client = openai.OpenAI(
+                api_key=api_key or "NOKEY",
+                base_url=f"https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/v1"
+            )
+
+    def get_available_models(self) -> dict:
+        try:
+            if not self.available_models or len(self.available_models) == 0:
+                self.available_models = {}
+                
+                api_prop = self.properties.get('api', '')
+                account_id = ""
+                api_key = api_prop
+                
+                if ':' in api_prop:
+                    account_id, api_key = api_prop.split(':', 1)
+                    
+                if account_id and api_key:
+                    response = requests.get(
+                        f'https://api.cloudflare.com/client/v4/accounts/{account_id}/ai/models/search',
+                        headers={'Authorization': f'Bearer {api_key}'}
+                    )
+                    if response.status_code == 200:
+                        data = response.json()
+                        if data.get('success'):
+                            for model in data.get('result',[]):
+                                if model.get('task', {}).get('name') in ('Text Generation', 'Chat Completions'):
+                                    self.available_models[model.get('name')] = {'display_name': model.get('name').split('/')[-1]}
+                                
+                if len(self.available_models) == 0 and getattr(self, 'client', None):
+                    for m in self.client.models.list():
+                        self.available_models[m.id] = {}
+                        
+            return self.available_models
+        except Exception as e:
+            dialog.simple_error(
+                parent = self.row.get_root() if self.row else None,
+                title = _('Instance Error'),
+                body = _('Could not retrieve models'),
+                error_log = e
+            )
+            logger.error(e)
+            if self.row:
+                self.row.get_parent().unselect_all()
+            return {}
+
 class GenericOpenAI(BaseInstance):
     instance_type = 'openai:generic'
     instance_type_display = _('OpenAI Compatible Instance')


### PR DESCRIPTION
Initially i though of adding a new __init__.py instance.instance_type cloudflare but that would be complected and need ui workaround then i changed my plan to
(account id:api key) as a whole will act as a api key and it works really good
https://developers.cloudflare.com/workers-ai/get-started/rest-api/
https://dash.cloudflare.com/ for account id