### PR TITLE
Fix LaTeX rendering for single dollar sign delimiters

### DIFF
--- a/src/widgets/blocks/__init__.py
+++ b/src/widgets/blocks/__init__.py
@@ -16,7 +16,7 @@ from ...sql_manager import generate_uuid, Instance as SQL
 patterns = [
     r'(?P<online_picture>!\[(?P<label>[^\]]*)\]\((?P<url>.*?)\))',
     r'(?P<code>```(?P<language>[a-zA-Z0-9_+\-]*)\n(?P<code_content>.*?)\n\s*```)',
-    r'(?P<latex>\\\[\s*(?P<latex_content1>.*?)\s*\\\]|\$\$\s*(?P<latex_content2>.*?)\s*\$\$)',
+    r'(?P<latex>\\\[\s*(?P<latex_content1>.*?)\s*\\\]|(?P<delim>\${1,2})\s*(?P<latex_content2>.*?)\s*(?P=delim))',
     r'(?P<table>(?:^|(?<=\n))\|[^\n]*\|[\s\xa0]*\n\|[\s\xa0\-|:]*\|[\s\xa0]*\n(?:\|[^\n]*\|(?:[\s\xa0]*\n|$))+)',
     r'(?P<line>^\s*-{3,}\s*$|\n-{3,}\n)'
 ]

--- a/src/widgets/blocks/__init__.py
+++ b/src/widgets/blocks/__init__.py
@@ -62,7 +62,8 @@ def text_to_block_list(raw_content:str):
                     )
 
         elif kind == 'latex':
-            content = match.group('latex_content1').strip() or match.group('latex_content2').strip()
+            rawcontent = match.group('latex_content1') or match.group('latex_content2') or ""
+            content = rawcontent.strip()
             if content:
                 if '\\' in content:
                     blocks.append(LatexRenderer(content=content))

--- a/src/widgets/blocks/__init__.py
+++ b/src/widgets/blocks/__init__.py
@@ -16,7 +16,7 @@ from ...sql_manager import generate_uuid, Instance as SQL
 patterns = [
     r'(?P<online_picture>!\[(?P<label>[^\]]*)\]\((?P<url>.*?)\))',
     r'(?P<code>```(?P<language>[a-zA-Z0-9_+\-]*)\n(?P<code_content>.*?)\n\s*```)',
-    r'(?P<latex>\\\[\s*(?P<latex_content1>.*?)\s*\\\]|(?P<delim>\${1,2})\s*(?P<latex_content2>.*?)\s*(?P=delim))',
+    r'(?P<latex>\\\[\s*(?P<latex_content1>.*?)\s*\\\]|\$\$\s*(?P<latex_content2>.*?)\s*\$\$|\$\s*(?P<latex_content3>.*?)\s*\$)',
     r'(?P<table>(?:^|(?<=\n))\|[^\n]*\|[\s\xa0]*\n\|[\s\xa0\-|:]*\|[\s\xa0]*\n(?:\|[^\n]*\|(?:[\s\xa0]*\n|$))+)',
     r'(?P<line>^\s*-{3,}\s*$|\n-{3,}\n)'
 ]
@@ -62,18 +62,30 @@ def text_to_block_list(raw_content:str):
                     )
 
         elif kind == 'latex':
-            rawcontent = match.group('latex_content1') or match.group('latex_content2') or ""
+            rawcontent = match.group('latex_content3') or ""
             content = rawcontent.strip()
             if content:
                 if '\\' in content:
-                    blocks.append(LatexRenderer(content=content))
-                else:
                     if len(blocks) > 0 and isinstance(blocks[-1], Text):
-                        blocks[-1].append_content(content)
+                        blocks[-1].append_content(LatexRenderer(content=content))
                     else:
                         blocks.append(
-                            Text(content=content)
+                            Text(content="")
                         )
+                        blocks[-1].append_content(LatexRenderer(content=content))
+            else:
+                rawcontent = match.group('latex_content1') or match.group('latex_content2') or ""
+                content = rawcontent.strip()
+                if content:
+                    if '\\' in content:
+                        blocks.append(LatexRenderer(content=content))
+                    else:
+                        if len(blocks) > 0 and isinstance(blocks[-1], Text):
+                            blocks[-1].append_content(content)
+                        else:
+                            blocks.append(
+                                Text(content=content)
+                            )
 
         elif kind == 'table':
             content = match.group(0)


### PR DESCRIPTION
### Description
This PR improves the LaTeX regex to correctly handle symbols wrapped in single dollar signs (e.g., `$\rightarrow$`).

Currently, some of these patterns are not being identified, causing them to be displayed as plain text. This update ensures they are properly captured and rendered, which is especially helpful for models that frequently use this format.

Note: This appears to be a slight oversight in the regex update from commit 5aaa706.
