### PR TITLE
Fix: Improve type safety of error handling

### DIFF
--- a/src/widgets/activities/transcriber.py
+++ b/src/widgets/activities/transcriber.py
@@ -126,9 +126,9 @@ class Transcriber(Gtk.Stack):
                 parent = self.get_root(),
                 title = _('Transcription Error'),
                 body = _('An error occurred while pulling speech recognition model'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             GLib.idle_add(self.close)
             return
         try:
@@ -156,9 +156,9 @@ class Transcriber(Gtk.Stack):
                 parent = self.get_root(),
                 title = _('Transcription Error'),
                 body = _('An error occurred while transcribing audio'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             GLib.idle_add(self.close)
             return
 

--- a/src/widgets/instances/ollama_instances.py
+++ b/src/widgets/instances/ollama_instances.py
@@ -241,9 +241,9 @@ class BaseInstance:
                     parent = bot_message.get_root(),
                     title = _('Instance Error'),
                     body = _('Message generation failed'),
-                    error_log = e
+                    error_log = str(e)
                 )
-                logger.error(e)
+                logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
 
@@ -363,9 +363,9 @@ class BaseInstance:
                     parent = self.row.get_root() if self.row else None,
                     title = _('Instance Error'),
                     body = _('Could not retrieve available models'),
-                    error_log = e
+                    error_log = str(e)
                 )
-                logger.error(e)
+                logger.exception(e)
         return {}
 
     def get_model_info(self, model_name:str) -> dict:
@@ -398,9 +398,9 @@ class BaseInstance:
                     parent = self.row.get_root() if self.row else None,
                     title = _('Error Pulling Model'),
                     body = model.get_name(),
-                    error_log = e
+                    error_log = str(e)
                 )
-                logger.error(e)
+                logger.exception(e)
             model.get_parent().get_parent().remove(model.get_parent())
 
     def upload_gguf(self, gguf_path:str):
@@ -606,7 +606,7 @@ class OllamaManaged(BaseInstance):
                         parent = self.row.get_root() if self.row else None,
                         title = _('Instance Error'),
                         body = _('Managed Ollama instance failed to start'),
-                        error_log = e
+                        error_log = str(e)
                     )
                 if self.row:
                     GLib.idle_add(self.row.get_parent().unselect_all)
@@ -727,9 +727,9 @@ class OllamaCloud(BaseInstance):
                     parent = self.row.get_root() if self.row else None,
                     title = _('Instance Error'),
                     body = _('Could not retrieve added models'),
-                    error_log = e
+                    error_log = str(e)
                 )
-                logger.error(e)
+                logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
         return {}

--- a/src/widgets/instances/ollama_instances.py
+++ b/src/widgets/instances/ollama_instances.py
@@ -341,16 +341,15 @@ class BaseInstance:
 
             return model_list
 
-            return [{'name': m.model} for m in models if m.model]
         except Exception as e:
             if self.instance_type != 'ollama:managed' or is_ollama_installed():
                 dialog.simple_error(
                     parent = self.row.get_root() if self.row else None,
                     title = _('Instance Error'),
                     body = _('Could not retrieve added models'),
-                    error_log = e
+                    error_log = str(e)
                 )
-                logger.error(e)
+                logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
         return []

--- a/src/widgets/instances/openai_instances.py
+++ b/src/widgets/instances/openai_instances.py
@@ -189,9 +189,9 @@ class BaseInstance:
                 parent = bot_message.get_root(),
                 title = _('Tool Error'),
                 body = _('An error occurred while running tool'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
 
         self.generate_response(bot_message, chat, messages, model)
 
@@ -238,9 +238,9 @@ class BaseInstance:
                     parent = bot_message.get_root(),
                     title = _('Instance Error'),
                     body = _('Message generation failed'),
-                    error_log = e
+                    error_log = str(e)
                 )
-                logger.error(e)
+                logger.exception(e)
                 if self.row:
                     GLib.idle_add(self.row.get_parent().unselect_all)
         bot_message.finish_generation()
@@ -314,9 +314,9 @@ class BaseInstance:
                 parent = self.row.get_root() if self.row else None,
                 title = _('Instance Error'),
                 body = _('Could not retrieve added models'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
             return {}
@@ -371,9 +371,9 @@ class Gemini(BaseInstance):
                 parent = self.row.get_root() if self.row else None,
                 title = _('Instance Error'),
                 body = _('Could not retrieve added models'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
         return {}
@@ -413,9 +413,9 @@ class Together(BaseInstance):
                 parent = self.row.get_root() if self.row else None,
                 title = _('Instance Error'),
                 body = _('Could not retrieve added models'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
         return {}
@@ -474,9 +474,9 @@ class OpenRouter(BaseInstance):
                 parent = self.row.get_root() if self.row else None,
                 title = _('Instance Error'),
                 body = _('Could not retrieve models'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
             return {}
@@ -513,9 +513,9 @@ class Fireworks(BaseInstance):
                 parent = self.row.get_root() if self.row else None,
                 title = _('Instance Error'),
                 body = _('Could not retrieve models'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
             return {}
@@ -546,9 +546,9 @@ class LambdaLabs(BaseInstance):
                 parent = self.row.get_root() if self.row else None,
                 title = _('Instance Error'),
                 body = _('Could not retrieve models'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
             return {}
@@ -625,9 +625,9 @@ class CompactifAI(BaseInstance):
                 parent=self.row.get_root() if self.row else None,
                 title=_('Instance Error'),
                 body=_('Could not retrieve CompactifAI models'),
-                error_log=e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
             return {}
@@ -715,9 +715,9 @@ class Cloudflare(BaseInstance):
                 parent = self.row.get_root() if self.row else None,
                 title = _('Instance Error'),
                 body = _('Could not retrieve models'),
-                error_log = e
+                error_log = str(e)
             )
-            logger.error(e)
+            logger.exception(e)
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
             return {}

--- a/src/widgets/voice.py
+++ b/src/widgets/voice.py
@@ -207,9 +207,9 @@ class MicrophoneButton(Gtk.Stack):
                     parent = button.get_root(),
                     title = _('Speech Recognition Error'),
                     body = _('An error occurred while pulling speech recognition model'),
-                    error_log = e
+                    error_log = str(e)
                 )
-                logger.error(e)
+                logger.exception(e)
                 return
             button.get_parent().set_visible_child_name("button")
 
@@ -240,9 +240,9 @@ class MicrophoneButton(Gtk.Stack):
                         parent = button.get_root(),
                         title = _('Speech Recognition Error'),
                         body = _('An error occurred while using speech recognition'),
-                        error_log = e
+                        error_log = str(e)
                     )
-                    logger.error(e)
+                    logger.exception(e)
                 finally:
                     stream.stop_stream()
                     stream.close()


### PR DESCRIPTION
A secondary unhandled exception caused by passing an exception type to the simple_error dialog box was somehow causing the instance manager to be greyed out as seen in #1171.  This should be resolved now and the dialog box should now appear as intended.

Update: I applied the same changes across the codebase. This should also fix #1167.

Fixes #1171, Fixes #1167