### PR TITLE
Fix: eradicate infinite loops during tool calls

### DIFF
--- a/src/widgets/instances/ollama_instances.py
+++ b/src/widgets/instances/ollama_instances.py
@@ -141,12 +141,12 @@ class BaseInstance:
                 params["options"]["seed"] = self.properties.get('seed')
 
         metadata_string = ""
-        tool_calls = []
         thought = ""
         content = ""
         try:
             bot_message.block_container.clear()
             while chat.busy:
+                tool_calls = []
                 params['messages'] = messages
                 response = self.client.chat(**params)
                 for chunk in response:


### PR DESCRIPTION
The list of tool_calls in ollama_instances was never being cleared, and thus resulted in all tool calls looping infinitely.

I spent more hours on this one line change than I would like to admit, and had to get some assistance.

Fixes #1127, Fixes #1189 