### PR TITLE
extract images on status code 206

### DIFF
--- a/src/widgets/attachments.py
+++ b/src/widgets/attachments.py
@@ -85,18 +85,15 @@ def extract_online_image(image_url: str, max_size: int) -> str | None:
         # parse Content-Range header
         # if all content has already been successfully fetched, set complete to true and continue
         content_range = image_response.headers.get('Content-Range')
-        if content_range is not None:
-            match = re.match(r'bytes (\d+)-(\d+)/(\d+|\*)', content_range)
-            if match:
-                _, end, total = match.groups()
-                if total != '*':
-                    complete = bool(int(total) == int(end) + 1)
-                else:
-                    raise requests.exceptions.ContentDecodingError('Failed to decode chunked response')
-            else:
-                raise requests.exceptions.InvalidHeader('Content-Range header is invalid')
-        else:
+        if content_range is None:
             raise requests.exceptions.InvalidHeader('Content-Range header is missing')
+        match = re.match(r'bytes (\d+)-(\d+)/(\d+|\*)', content_range)
+        if match is None:
+            raise requests.exceptions.InvalidHeader('Content-Range header is invalid')
+        _, end, total = match.groups()
+        if total == '*':
+            raise requests.exceptions.ContentDecodingError('Failed to decode chunked response')
+        complete = bool(int(total) == int(end) + 1)
     if image_response.status_code == 200 or complete:
         image_data = None
         image_path = os.path.join(str(cache_dir), 'image_web.jpg')

--- a/src/widgets/attachments.py
+++ b/src/widgets/attachments.py
@@ -80,9 +80,21 @@ def extract_content(file_type:str, file_path:str) -> str:
 def extract_online_image(image_url: str, max_size: int) -> str | None:
     image_response = requests.get(url=image_url, headers={"User-Agent": "AlpacaBot"})
     image_response.raise_for_status()
-    if image_response.status_code == 200:
+    complete = False
+    # parse start, end, and total from Content-Range header
+    # if all content has already been successfully fetched, set complete to true and continue
+    if image_response.status_code == 206:
+        match = re.match(r"bytes (\d+)-(\d+)/(\d+|\*)", image_response.headers["Content-Range"])
+        if match:
+            start, end, total = match.groups()
+            start = int(start)
+            end = int(end)
+            if total != "*":
+                total = int(total)
+                complete = (end + 1 == total)
+    if image_response.status_code == 200 or complete:
         image_data = None
-        image_path = os.path.join(cache_dir, 'image_web.jpg')
+        image_path = os.path.join(str(cache_dir), 'image_web.jpg')
         with open(image_path, 'wb') as handler:
             handler.write(image_response.content)
         image_data = extract_image(image_path, max_size)

--- a/src/widgets/attachments.py
+++ b/src/widgets/attachments.py
@@ -81,17 +81,22 @@ def extract_online_image(image_url: str, max_size: int) -> str | None:
     image_response = requests.get(url=image_url, headers={"User-Agent": "AlpacaBot"})
     image_response.raise_for_status()
     complete = False
-    # parse start, end, and total from Content-Range header
-    # if all content has already been successfully fetched, set complete to true and continue
     if image_response.status_code == 206:
-        match = re.match(r"bytes (\d+)-(\d+)/(\d+|\*)", image_response.headers["Content-Range"])
-        if match:
-            start, end, total = match.groups()
-            start = int(start)
-            end = int(end)
-            if total != "*":
-                total = int(total)
-                complete = (end + 1 == total)
+        # parse Content-Range header
+        # if all content has already been successfully fetched, set complete to true and continue
+        content_range = image_response.headers.get('Content-Range')
+        if content_range is not None:
+            match = re.match(r'bytes (\d+)-(\d+)/(\d+|\*)', content_range)
+            if match:
+                _, end, total = match.groups()
+                if total != '*':
+                    complete = bool(int(total) == int(end) + 1)
+                else:
+                    raise requests.exceptions.ContentDecodingError('Failed to decode chunked response')
+            else:
+                raise requests.exceptions.InvalidHeader('Content-Range header is invalid')
+        else:
+            raise requests.exceptions.InvalidHeader('Content-Range header is missing')
     if image_response.status_code == 200 or complete:
         image_data = None
         image_path = os.path.join(str(cache_dir), 'image_web.jpg')


### PR DESCRIPTION
I noticed that some websites return images with status code 206.  Alpaca is set to only extract images that return status code 200, and thus Alpaca drops the successfully fetched image.  inline_picture.py then throws a NoneType error:

```
ERROR	[inline_picture.py | __init__] argument should be a bytes-like object or ASCII string, not 'NoneType'
Traceback (most recent call last):
  File "/app/share/Alpaca/alpaca/widgets/blocks/inline_picture.py", line 27, in __init__
    image_data = base64.b64decode(self.content)
  File "/usr/lib/python3.13/base64.py", line 83, in b64decode
    s = _bytes_from_decode_data(s)
  File "/usr/lib/python3.13/base64.py", line 45, in _bytes_from_decode_data
    raise TypeError("argument should be a bytes-like object or ASCII "
                    "string, not %r" % s.__class__.__name__) from None
TypeError: argument should be a bytes-like object or ASCII string, not 'NoneType'
```

I think in the case of images, it would generally be safe to just do `if image_response.status_code in [200, 206]` because the entire image is usually returned in the response; however, I took a more cautious approach and parsed the header to ensure the whole image has been successfully fetched.

