### PR TITLE
add llmman instance type

### DIFF
--- a/src/widgets/instances/__init__.py
+++ b/src/widgets/instances/__init__.py
@@ -69,7 +69,7 @@ class InstancePreferencesDialog(Adw.Dialog):
         self.set_simple_element_value(self.name_el)
 
         self.set_simple_element_value(self.url_el)
-        if self.instance.instance_type in ('ollama', 'ollama:managed', 'openai:generic', 'llama_cpp'):
+        if self.instance.instance_type in ('ollama', 'ollama:managed', 'ollama:llmman', 'openai:generic', 'llama_cpp'):
             if self.instance.instance_type == 'ollama:managed':
                 try:
                     port = int(self.instance.properties.get('url').split(':')[-1])
@@ -92,7 +92,7 @@ class InstancePreferencesDialog(Adw.Dialog):
             if self.instance.instance_type == 'cloudflare':
                 normal_api_title = _('API Key (account_id:api_key)')
             else:
-                normal_api_title = _('API Key (Optional)' if self.instance.instance_type == 'ollama' else _('API Key'))
+                normal_api_title = _('API Key (Optional)' if self.instance.instance_type in ('ollama', 'ollama:llmman') else _('API Key'))
             
             unchanged_api_title = _('API Key (Unchanged)')
             

--- a/src/widgets/instances/ollama_instances.py
+++ b/src/widgets/instances/ollama_instances.py
@@ -733,3 +733,24 @@ class OllamaCloud(BaseInstance):
             if self.row:
                 GLib.idle_add(self.row.get_parent().unselect_all)
         return {}
+
+class Llmman(BaseInstance):
+    # https://github.com/llmmanorg/llmman serves the Ollama API on port 17434.
+    # Models are pulled by name (OCI or hf.co), so there is no library to browse.
+    instance_type = 'ollama:llmman'
+    instance_type_display = 'llmman'
+    description = _('Local or remote AI instance served by llmman')
+
+    default_properties = {**Ollama.default_properties, 'url': 'http://localhost:17434'}
+
+    def __init__(self, instance_id:str, properties:dict):
+        self.instance_id = instance_id
+        self.properties = {}
+        self.row = None
+        for key in self.default_properties:
+            self.properties[key] = properties.get(key, self.default_properties.get(key))
+
+        self.client = None
+
+    def get_available_models(self) -> dict:
+        return {}


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434.

- New `Llmman` class in `src/widgets/instances/ollama_instances.py`, a direct `BaseInstance` subclass (discovery uses `BaseInstance.__subclasses__()`) reusing `Ollama.default_properties` with the URL swapped to `http://localhost:17434`, so chat, tools, pull, show and delete go through the existing `ollama` client unchanged.
- `instance_type = 'ollama:llmman'` follows the `ollama:managed` / `ollama:cloud` naming so the existing `'ollama' in type` dispatch in `create_instance_row` loads saved instances.
- `get_available_models()` returns `{}`: llmman has no ollama.com library; models are pulled by name (`gemma4`, `hf.co/unsloth/Qwen3.5-0.8B-GGUF`) via the existing "Pull Model" action.
- `src/widgets/instances/__init__.py`: URL field editable and API key labelled "Optional" for `ollama:llmman`.

Per CONTRIBUTING this should have an issue first; happy to open one if preferred.

**Testing:** `python3 -m py_compile` and `ruff check` on both files (no new findings beyond the pre-existing gettext `F821 '_'` pattern); no GTK run or live `llmman serve` test.

> AI-assisted, reviewed before submitting.
